### PR TITLE
Fix arrow tip cropping issue (xivplan#37)

### DIFF
--- a/src/prefabs/Arrow.tsx
+++ b/src/prefabs/Arrow.tsx
@@ -73,15 +73,22 @@ const HIGHLIGHT_STROKE_WIDTH = STROKE_WIDTH + (SELECTED_PROPS.strokeWidth ?? 0);
 const ArrowRenderer: React.FC<RendererProps<ArrowObject>> = ({ object }) => {
     const showHighlight = useShowHighlight(object);
 
+    // respect the stroke width when calculating the pointer width to avoid cropping
+    const pointerLength = DEFAULT_ARROW_HEIGHT * 0.15;
+    const tangent = pointerLength / (DEFAULT_ARROW_WIDTH * 0.5);
+    const cotangent = 1 / tangent;
+    const cosecant = 1 / Math.sin(Math.atan(tangent));
+    const lengthOffset = STROKE_WIDTH * 0.5 * (1 + cosecant);
+    const widthOffset = STROKE_WIDTH * (cotangent + cosecant);
+
     const arrowProps: ArrowConfig = {
         points: POINTS,
         width: DEFAULT_ARROW_WIDTH,
         height: DEFAULT_ARROW_HEIGHT,
         scaleX: object.width / DEFAULT_ARROW_WIDTH,
         scaleY: object.height / DEFAULT_ARROW_HEIGHT,
-        pointerLength: DEFAULT_ARROW_HEIGHT * 0.15,
-        // respect the stroke width when calculating the pointer width to avoid cropping
-        pointerWidth: DEFAULT_ARROW_WIDTH - STROKE_WIDTH * Math.sqrt(3),
+        pointerLength: pointerLength - lengthOffset,
+        pointerWidth: DEFAULT_ARROW_WIDTH - widthOffset,
         strokeWidth: STROKE_WIDTH,
         lineCap: 'round',
         pointerAtBeginning: !!object.arrowBegin,

--- a/src/prefabs/Arrow.tsx
+++ b/src/prefabs/Arrow.tsx
@@ -80,7 +80,8 @@ const ArrowRenderer: React.FC<RendererProps<ArrowObject>> = ({ object }) => {
         scaleX: object.width / DEFAULT_ARROW_WIDTH,
         scaleY: object.height / DEFAULT_ARROW_HEIGHT,
         pointerLength: DEFAULT_ARROW_HEIGHT * 0.15,
-        pointerWidth: DEFAULT_ARROW_WIDTH * 0.8,
+        // respect the stroke width when calculating the pointer width to avoid cropping
+        pointerWidth: DEFAULT_ARROW_WIDTH - STROKE_WIDTH * Math.sqrt(3),
         strokeWidth: STROKE_WIDTH,
         lineCap: 'round',
         pointerAtBeginning: !!object.arrowBegin,


### PR DESCRIPTION
fix #37.

## Comparison

Before:
![image](https://github.com/user-attachments/assets/bc5697cf-8087-4cb1-8350-2805e59d35c1)

After:
![image](https://github.com/user-attachments/assets/d055f11a-b89c-4ced-870a-279ff89a8388)

## `.xivplan` files for testing

<details>

```json
{
  "nextId": 3,
  "arena": {
    "shape": "rectangle",
    "width": 600,
    "height": 800,
    "padding": 120,
    "grid": {
      "type": "rectangle",
      "rows": 1,
      "columns": 1
    }
  },
  "steps": [
    {
      "objects": [
        {
          "type": "arrow",
          "color": "#ff0000",
          "opacity": 100,
          "width": 90,
          "height": 450,
          "rotation": 0,
          "arrowEnd": true,
          "x": 0,
          "y": 0,
          "id": 1
        },
        {
          "type": "arrow",
          "color": "#ff0000",
          "opacity": 100,
          "width": 90,
          "height": 450,
          "rotation": 0,
          "arrowEnd": true,
          "x": 120,
          "y": 0,
          "id": 2
        }
      ]
    }
  ]
}
```

</details>


## Maths explained, if someone ever wonders

<details>

![image](https://github.com/user-attachments/assets/e8a752a7-b82b-4124-b0f3-3ff1783e5377)

</details>
