### PR TITLE
Fix duplicated percent-encoding in status search query parameter (#39)

### DIFF
--- a/src/panel/StatusSearch.tsx
+++ b/src/panel/StatusSearch.tsx
@@ -138,7 +138,7 @@ async function fetchStatuses(search: string, signal: AbortSignal, language: Lang
             language,
             sheets: 'Status',
             fields: 'Name,Icon,MaxStacks',
-            query: `Name~"${encodeURIComponent(search)}"`,
+            query: `Name~"${search}"`,
             ...(cursor && { cursor }),
         });
 


### PR DESCRIPTION
Fix #39 

The current implement of searching status from xivapi.com introduces duplicated percent-encoding in its name query parameter, resulting in names with special characters such as space not searchable.

Currently when you type `water r` in the search box, the following request will be made:

`https://beta.xivapi.com/api/1/search?language=en&sheets=Status&fields=Name%2CIcon%2CMaxStacks&query=Name~%22water%2520r%22`

Note the `%2520` part is the result of percent-encoding of `%20`.

The current implement of how the request query parameters will be made is:

https://github.com/joelspadin/xivplan/blob/b33fd434259cb501c7bff390da652964688a25c9/src/panel/StatusSearch.tsx#L137-L143

Note that we `encodeURIComponent` the value of the name inside `URLSearchParams`. According to [this MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams#percent_encoding), if you pass value that have been processed by `encodeURIComponent` in `URLSearchParams` values, it will be encoded again:

> If you append a key/value pair with a percent-encoded key, that key is treated as unencoded and is encoded again.

You can verify via the following JavaScript spinet:

```javascript
const data = 'foo bar'
const params = new URLSearchParams({
  decoded: data,
  encoded: encodeURIComponent(data)
});
console.log(params.toString())
// decoded=foo+bar&encoded=foo%2520bar
```

So remove the `encodeURIComponent` will fix the problem.