### PR TITLE
Fix tether arrow tip cropping issue (#41)

### DIFF
--- a/src/prefabs/Tethers.tsx
+++ b/src/prefabs/Tethers.tsx
@@ -202,7 +202,8 @@ const CloseTetherRenderer: React.FC<TetherProps> = ({ object, scene, showHighlig
 };
 
 const FarTetherRenderer: React.FC<TetherProps> = ({ object, scene, showHighlight, startObject, endObject }) => {
-    const [start, end] = getTetherPoints(scene, startObject, endObject, object.width);
+    const addOffset = object.width / Math.sin(Math.atan(0.5)) / 2;
+    const [start, end] = getTetherPoints(scene, startObject, endObject, addOffset);
 
     const arrowProps: ArrowConfig = {
         points: [start.x, start.y, end.x, end.y],
@@ -322,7 +323,7 @@ const TetherRenderer: React.FC<RendererProps<Tether>> = ({ object }) => {
     const isSelectable = editMode === EditMode.Normal;
 
     // Cache so overlapping shapes with opacity appear as one object.
-    useKonvaCache(groupRef, [object, startObject, endObject, showHighlight]);
+    useKonvaCache(groupRef, { offset: object.width }, [object, startObject, endObject, showHighlight]);
 
     return (
         <SelectableObject object={object}>

--- a/src/useKonvaCache.ts
+++ b/src/useKonvaCache.ts
@@ -3,20 +3,26 @@
 import { Node } from 'konva/lib/Node';
 import { DependencyList, useEffect, useState } from 'react';
 
+type CacheOptions = Exclude<Parameters<Node['cache']>[0], undefined>;
 export function useKonvaCache(ref: React.RefObject<Node>, deps: DependencyList): void;
 export function useKonvaCache(ref: React.RefObject<Node>, enabled: boolean, deps: DependencyList): void;
+export function useKonvaCache(ref: React.RefObject<Node>, options: CacheOptions, deps: DependencyList): void;
 export function useKonvaCache(
     ref: React.RefObject<Node>,
-    enabledOrDeps: boolean | DependencyList,
+    enabledOrOptionsOrDeps: boolean | CacheOptions | DependencyList,
     deps?: DependencyList,
 ) {
     let enabled = true;
+    let options: CacheOptions | undefined;
 
-    if (typeof enabledOrDeps === 'boolean') {
-        enabled = enabledOrDeps;
+    if (typeof enabledOrOptionsOrDeps === 'boolean') {
+        enabled = enabledOrOptionsOrDeps;
         deps = deps ?? [];
+    } else if (Array.isArray(enabledOrOptionsOrDeps)) {
+        deps = enabledOrOptionsOrDeps;
     } else {
-        deps = enabledOrDeps;
+        options = enabledOrOptionsOrDeps as CacheOptions;
+        deps = deps ?? [];
     }
 
     // On changes to dependencies, immediately clear the cache to avoid a flicker
@@ -43,7 +49,7 @@ export function useKonvaCache(
     // Then re-cache the object after it has been drawn.
     useEffect(() => {
         if (enabled) {
-            ref.current?.cache();
+            ref.current?.cache(options);
         }
     }, [enabled, ref.current, ...deps]);
 }


### PR DESCRIPTION
Fix #41.

Similar to #37 and #38, the arrow length tip should be retracted by `s/sin(θ)`. As the caching boundary calculated by the `getClientRect` of Arrows does not respect `strokeWidth`, we shall modify the `useKonvaCache` to pass offest option to increase cache canvas size.

## Comparison

Before:
![image](https://github.com/user-attachments/assets/9f98718c-fb8e-4d2b-9d56-21791c3130c4)

After:
![image](https://github.com/user-attachments/assets/d7528b12-26fb-4e93-ab0b-259667afc013)

## `.xivplan` files for testing

<details>

```json{
  "nextId": 9,
  "arena": {
    "shape": "rectangle",
    "width": 600,
    "height": 600,
    "padding": 120,
    "grid": {
      "type": "rectangle",
      "rows": 4,
      "columns": 4
    }
  },
  "steps": [
    {
      "objects": [
        {
          "type": "rect",
          "color": "#fc972b",
          "opacity": 35,
          "width": 400,
          "height": 30,
          "rotation": 0,
          "x": 0,
          "y": 0,
          "id": 5
        },
        {
          "type": "tether",
          "tether": "far",
          "startId": 7,
          "endId": 6,
          "width": 50,
          "color": "#00e622",
          "opacity": 100,
          "id": 8
        },
        {
          "type": "rect",
          "color": "#ff0000",
          "opacity": 35,
          "width": 30,
          "height": 30,
          "rotation": 0,
          "x": 215,
          "y": 0,
          "id": 6
        },
        {
          "type": "rect",
          "color": "#ff0000",
          "opacity": 35,
          "width": 30,
          "height": 30,
          "rotation": 0,
          "x": -215,
          "y": 0,
          "id": 7
        }
      ]
    }
  ]
}
```