### PR TITLE
Display hours instead of minutes when the time is more than 3600s

### DIFF
--- a/src/prefabs/StatusIcon.tsx
+++ b/src/prefabs/StatusIcon.tsx
@@ -42,7 +42,8 @@ const IconTimer: React.FC<IconTimerProps> = ({ time, width, height }) => {
     const text = useMemo(() => {
         if (time < 60) {
             return time.toString();
-        } else if (time < 3600) {
+        }
+        if (time < 3600) {
             return `${Math.floor(time / 60)}m`;
         }
 

--- a/src/prefabs/StatusIcon.tsx
+++ b/src/prefabs/StatusIcon.tsx
@@ -42,9 +42,11 @@ const IconTimer: React.FC<IconTimerProps> = ({ time, width, height }) => {
     const text = useMemo(() => {
         if (time < 60) {
             return time.toString();
+        } else if (time < 3600) {
+            return `${Math.floor(time / 60)}m`;
         }
 
-        return `${Math.floor(time / 60)}m`;
+        return `${Math.floor(time / 3600)}h`;
     }, [time]);
 
     const fontSize = Math.max(14, height / 3);


### PR DESCRIPTION
Nice-to-haves.

![image](https://github.com/user-attachments/assets/2a472a65-432a-4119-8d5d-dec275fbdaea)
