### PR TITLE
Allowing zero padding arena presets

### DIFF
--- a/src/StepSelect.tsx
+++ b/src/StepSelect.tsx
@@ -49,12 +49,8 @@ export const StepSelect: React.FC = () => {
         [dispatch],
     );
 
-    const maxWidth = useMemo(() => {
-        return scene.arena.width + scene.arena.padding * 2;
-    }, [scene]);
-
     return (
-        <div className={classes.root} style={{ maxWidth }}>
+        <div className={classes.root} style={{ maxWidth: '100%' }}>
             <div className={classes.listWrapper}>
                 <TabList
                     size="small"

--- a/src/panel/ArenaShapeEdit.tsx
+++ b/src/panel/ArenaShapeEdit.tsx
@@ -34,7 +34,7 @@ export const ArenaShapeEdit: React.FC = () => {
                     </SegmentedGroup>
                 </Field>
                 <Field label="Padding" className={classes.cell}>
-                    <SpinButton min={20} max={500} step={10} value={padding} onChange={onPaddingChanged} />
+                    <SpinButton min={0} max={500} step={10} value={padding} onChange={onPaddingChanged} />
                 </Field>
             </div>
             <div className={classes.row}>


### PR DESCRIPTION
I found it cumbersome when I want to quickly draft a zero padding arena diagram.

- The current arena padding color is subject to theme - either rice color `#f0e1ca` or dark gray `#292929` - which is not customizable.
- The arena padding settings has been limited to 20px at least.
- The screenshot functionality does not provide a "Arena Only" screenshot, that is to say ignoring all the paddings. 

Although "Arena Only" screenshot is possible through `stage.toBlob` by Konva, it is far more complex to change the UI than just allowing user to set the padding down to zero. We could also add 20px to the padding of the `SceneRenderer` which should look the same as the current padding limit of 20px minimum when necessary.



