### PR TITLE
Allow objects to have zero opacity

### DIFF
--- a/src/OpacitySlider.tsx
+++ b/src/OpacitySlider.tsx
@@ -15,7 +15,7 @@ export const OpacitySlider: React.FC<OpacitySliderProps> = ({ label, ...props })
         <Field label={label ?? 'Opacity'}>
             <div className={classes.wrapper}>
                 <Slider
-                    min={5}
+                    min={0}
                     max={100}
                     step={5}
                     aria-valuetext={ariaValueText}


### PR DESCRIPTION
Currently the minimum opacity of objects is limited to 5%. I found it difficult to use when you have to use auxiliary object but don't want to show them in your plan.


Take this Spirit Taker diagram in FRU P4 Darklit Dragonsong as an example. This diagram shows the quadrilateral where Gaia may possibly stay after Spirit Taker:

![image](https://github.com/user-attachments/assets/2152777a-ff83-4d07-afac-bbffab81d5d0)

I want to show the quadrilateral made by four tethers but not the boss range in my next step, which shows where MT show not stay in order to keep the furthest distance between MT and Gaia:

![image](https://github.com/user-attachments/assets/d4c7c5e2-1d0e-4a8e-9e29-615e2cfedc4f)

Although it seems okay to have 5% opacity which looks almost transparent, why not just allow objects to have zero opacity as there have user cases requiring it? 

Thanks again if you can consider this PR.
