### PR TITLE
Let dragging an object update the entire scene.

### DIFF
--- a/src/SceneProvider.tsx
+++ b/src/SceneProvider.tsx
@@ -78,6 +78,8 @@ export type ArenaAction =
 export interface ObjectUpdateAction {
     type: 'update';
     value: SceneObject | readonly SceneObject[];
+    /* When true, skips appending to the state history, directly applying the update to the present state. */
+    skipHistoryUpdate?: boolean;
 }
 
 export interface ObjectAddAction {

--- a/src/undo/undoReducer.ts
+++ b/src/undo/undoReducer.ts
@@ -71,12 +71,19 @@ export function createUndoReducer<S, A extends object>(
                 };
             }
         }
-
-        return {
-            past: [state.present, ...state.past].slice(0, historyLimit),
-            present: reducer(state.present, action),
-            future: [],
-        };
+        if ('skipHistoryUpdate' in action && action.skipHistoryUpdate) {
+            return {
+                past: state.past,
+                present: reducer(state.present, action),
+                future: state.future,
+            };
+        } else {
+            return {
+                past: [state.present, ...state.past].slice(0, historyLimit),
+                present: reducer(state.present, action),
+                future: [],
+            };
+        }
     };
 }
 


### PR DESCRIPTION
This should have no visible effect for most cases, but will cause any tethers attached to the dragged object to update in real time rather than only at the end.

Instead of using a temporary "drag position" to skip history updates, explicitly signal to the UndoRedoReducer that the history should not be updated on any drag event except onDragStart. This technically means there's a no-op entry in the history until onDragMove is called, but I couldn't find a way to trigger such a scenario (click+hold doesn't trigger onDragStart).