### PR TITLE
Highlight ('spotlight') the object in the scene when hovering over its entry in the scene list

### DIFF
--- a/src/SelectionContext.ts
+++ b/src/SelectionContext.ts
@@ -8,3 +8,5 @@ export type SceneSelection = ReadonlySet<number>;
 export type SelectionState = [SceneSelection, Dispatch<SetStateAction<SceneSelection>>];
 
 export const SelectionContext = createContext<SelectionState>([new Set(), () => undefined]);
+
+export const SpotlightContext = createContext<SelectionState>([new Set(), () => undefined]);

--- a/src/SelectionProvider.tsx
+++ b/src/SelectionProvider.tsx
@@ -1,8 +1,13 @@
 import React, { PropsWithChildren, useState } from 'react';
-import { SceneSelection, SelectionContext } from './SelectionContext';
+import { SceneSelection, SelectionContext, SpotlightContext } from './SelectionContext';
 
 export const SelectionProvider: React.FC<PropsWithChildren> = ({ children }) => {
     const state = useState<SceneSelection>(new Set());
+    const spotlightState = useState<SceneSelection>(new Set());
 
-    return <SelectionContext value={state}>{children}</SelectionContext>;
+    return (
+        <SelectionContext value={state}>
+            <SpotlightContext value={spotlightState}>{children}</SpotlightContext>
+        </SelectionContext>
+    );
 };

--- a/src/panel/ObjectList.tsx
+++ b/src/panel/ObjectList.tsx
@@ -19,7 +19,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { makeStyles, mergeClasses, shorthands, tokens } from '@fluentui/react-components';
 import React from 'react';
 import { SceneObject } from '../scene';
-import { addSelection, selectSingle, toggleSelection, useSelection } from '../selection';
+import { addSelection, selectNone, selectSingle, toggleSelection, useSelection, useSpotlight } from '../selection';
 import { reversed } from '../util';
 import { getListComponent } from './ListComponentRegistry';
 
@@ -91,6 +91,7 @@ interface SortableItemProps {
 const SortableItem: React.FC<SortableItemProps> = ({ object }) => {
     const classes = useStyles();
     const [selection, setSelection] = useSelection();
+    const [, setSpotlight] = useSpotlight();
     const isSelected = selection.has(object.id);
 
     const onClick = (e: React.MouseEvent) => {
@@ -101,6 +102,15 @@ const SortableItem: React.FC<SortableItemProps> = ({ object }) => {
         } else {
             setSelection(selectSingle(object.id));
         }
+    };
+
+    // onMouseLeave events may be skipped sometimes if the mouse is moving fast enough into another
+    // SortableItem, but there will always be a terminal onMouseLeave when exiting the list.
+    const onMouseEnter = () => {
+        setSpotlight(selectSingle(object.id));
+    };
+    const onMouseLeave = () => {
+        setSpotlight(selectNone());
     };
 
     const Component = getListComponent(object);
@@ -118,6 +128,8 @@ const SortableItem: React.FC<SortableItemProps> = ({ object }) => {
             style={style}
             className={mergeClasses(isDragging && classes.draggingWrapper)}
             onClick={onClick}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
             {...attributes}
             {...listeners}
         >

--- a/src/prefabs/Arrow.tsx
+++ b/src/prefabs/Arrow.tsx
@@ -6,7 +6,7 @@ import { getDragOffset, registerDropHandler } from '../DropHandler';
 import { getArrowStrokeExtent } from '../arrowUtil';
 import { DetailsItem } from '../panel/DetailsItem';
 import { ListComponentProps, registerListComponent } from '../panel/ListComponentRegistry';
-import { registerRenderer, RendererProps } from '../render/ObjectRegistry';
+import { RendererProps, registerRenderer } from '../render/ObjectRegistry';
 import { LayerName } from '../render/layers';
 import { ArrowObject, ObjectType } from '../scene';
 import { COLOR_RED } from '../theme';

--- a/src/prefabs/Arrow.tsx
+++ b/src/prefabs/Arrow.tsx
@@ -6,16 +6,16 @@ import { getDragOffset, registerDropHandler } from '../DropHandler';
 import { getArrowStrokeExtent } from '../arrowUtil';
 import { DetailsItem } from '../panel/DetailsItem';
 import { ListComponentProps, registerListComponent } from '../panel/ListComponentRegistry';
-import { RendererProps, registerRenderer } from '../render/ObjectRegistry';
+import { registerRenderer, RendererProps } from '../render/ObjectRegistry';
 import { LayerName } from '../render/layers';
 import { ArrowObject, ObjectType } from '../scene';
-import { COLOR_RED, SELECTED_PROPS } from '../theme';
+import { COLOR_RED } from '../theme';
 import { usePanelDrag } from '../usePanelDrag';
 import { CompositeReplaceGroup } from './CompositeReplaceGroup';
 import { HideCutoutGroup } from './HideGroup';
 import { PrefabIcon } from './PrefabIcon';
 import { ResizeableObjectContainer } from './ResizeableObjectContainer';
-import { useShowHighlight } from './highlight';
+import { useHighlightProps } from './highlight';
 
 // TODO: This would be a lot nicer if you could just click on start position
 // and drag to end position instead of having a set initial size/rotation.
@@ -71,10 +71,8 @@ registerDropHandler<ArrowObject>(ObjectType.Arrow, (object, position) => {
 const STROKE_WIDTH = DEFAULT_ARROW_WIDTH / 5;
 const POINTS = [DEFAULT_ARROW_WIDTH / 2, DEFAULT_ARROW_HEIGHT, DEFAULT_ARROW_WIDTH / 2, 0];
 
-const HIGHLIGHT_STROKE_WIDTH = STROKE_WIDTH + (SELECTED_PROPS.strokeWidth ?? 0);
-
 const ArrowRenderer: React.FC<RendererProps<ArrowObject>> = ({ object }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
 
     const pointerLength = DEFAULT_ARROW_HEIGHT * 0.15;
 
@@ -99,12 +97,16 @@ const ArrowRenderer: React.FC<RendererProps<ArrowObject>> = ({ object }) => {
         <ResizeableObjectContainer object={object} transformerProps={{ centeredScaling: true }}>
             {(groupProps) => (
                 <Group {...groupProps} listening={!object.hide}>
-                    {showHighlight && (
-                        <Arrow {...arrowProps} {...SELECTED_PROPS} strokeWidth={HIGHLIGHT_STROKE_WIDTH} />
+                    {highlightProps && (
+                        <Arrow
+                            {...arrowProps}
+                            {...highlightProps}
+                            strokeWidth={STROKE_WIDTH + (highlightProps.strokeWidth ?? 0)}
+                        />
                     )}
                     <Rect width={object.width} height={object.height} fill="transparent" />
                     <HideCutoutGroup>
-                        <CompositeReplaceGroup enabled={showHighlight} opacity={object.opacity / 100}>
+                        <CompositeReplaceGroup enabled={!!highlightProps} opacity={object.opacity / 100}>
                             <Arrow {...arrowProps} fill={object.color} stroke={object.color} />
                         </CompositeReplaceGroup>
                     </HideCutoutGroup>

--- a/src/prefabs/DrawObjectRenderer.tsx
+++ b/src/prefabs/DrawObjectRenderer.tsx
@@ -6,33 +6,33 @@ import { ListComponentProps, registerListComponent } from '../panel/ListComponen
 import { RendererProps, registerRenderer } from '../render/ObjectRegistry';
 import { LayerName } from '../render/layers';
 import { DrawObject, ObjectType } from '../scene';
-import { HIGHLIGHT_WIDTH, SELECTED_PROPS } from '../theme';
+import { HIGHLIGHT_WIDTH } from '../theme';
 import { DRAW_LINE_PROPS } from './DrawObjectStyles';
 import { HideCutoutGroup } from './HideGroup';
 import { ResizeableObjectContainer } from './ResizeableObjectContainer';
-import { useShowHighlight } from './highlight';
+import { useHighlightProps } from './highlight';
 
 function getLinePoints(object: DrawObject) {
     return object.points.map((v, i) => v * (i % 2 === 0 ? object.width : -object.height));
 }
 
 export const DrawObjectRenderer: React.FC<RendererProps<DrawObject>> = ({ object }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const points = getLinePoints(object);
 
     return (
         <ResizeableObjectContainer
             object={object}
             cache
-            cacheKey={showHighlight}
+            cacheKey={highlightProps}
             transformerProps={{ centeredScaling: true }}
         >
             {(groupProps) => (
                 <Group {...groupProps} offsetX={0} offsetY={0} opacity={object.opacity / 100}>
-                    {showHighlight && (
+                    {highlightProps && (
                         <Line
                             {...DRAW_LINE_PROPS}
-                            {...SELECTED_PROPS}
+                            {...highlightProps}
                             points={points}
                             strokeWidth={object.brushSize + HIGHLIGHT_WIDTH}
                         />

--- a/src/prefabs/Enemies.tsx
+++ b/src/prefabs/Enemies.tsx
@@ -15,7 +15,6 @@ import {
     DEFAULT_ENEMY_COLOR,
     DEFAULT_ENEMY_OPACITY,
     getEnemyTextConfig,
-    SELECTED_PROPS,
     useSceneTheme,
 } from '../theme';
 import { useKonvaCache } from '../useKonvaCache';
@@ -24,7 +23,7 @@ import { makeDisplayName } from '../util';
 import { HideGroup } from './HideGroup';
 import { PrefabIcon } from './PrefabIcon';
 import { RadiusObjectContainer } from './RadiusObjectContainer';
-import { useShowHighlight } from './highlight';
+import { useHighlightProps } from './highlight';
 
 const DEFAULT_SIZE = 32;
 
@@ -93,7 +92,7 @@ interface RingProps extends ShapeConfig {
     name?: string;
     radius: number;
     color: string;
-    isSelected?: boolean;
+    highlightProps?: ShapeConfig;
 }
 
 interface EnemyLabelProps extends TextConfig {
@@ -147,7 +146,7 @@ function getShapeProps(color: string, radius: number, strokeRatio: number, minSt
     };
 }
 
-const CircleRing: React.FC<RingProps> = ({ radius, color, isSelected, opacity, ...props }) => {
+const CircleRing: React.FC<RingProps> = ({ radius, color, highlightProps, opacity, ...props }) => {
     const outerProps = getShapeProps(color, radius, OUTER_STROKE_RATIO, OUTER_STROKE_MIN);
     const innerProps = getShapeProps(color, radius, INNER_STROKE_RATIO, INNER_STROKE_MIN);
     const innerRadius = getInnerRadius(radius);
@@ -155,7 +154,7 @@ const CircleRing: React.FC<RingProps> = ({ radius, color, isSelected, opacity, .
 
     return (
         <>
-            {isSelected && <Circle radius={radius} {...SELECTED_PROPS} />}
+            {highlightProps && <Circle radius={radius} {...highlightProps} />}
 
             <HideGroup opacity={opacity} {...props}>
                 <Circle {...outerProps} radius={outerRadius} />
@@ -175,7 +174,7 @@ const DirectionalRing: React.FC<DirectionalRingProps> = ({
     color,
     opacity,
     rotation,
-    isSelected,
+    highlightProps,
     groupRef,
     ...props
 }) => {
@@ -190,7 +189,7 @@ const DirectionalRing: React.FC<DirectionalRingProps> = ({
 
     return (
         <>
-            {isSelected && <Circle radius={radius} {...SELECTED_PROPS} />}
+            {highlightProps && <Circle radius={radius} {...highlightProps} />}
 
             <HideGroup opacity={opacity} ref={groupRef} rotation={rotation} {...props}>
                 <Circle radius={radius} fill="transparent" />
@@ -225,7 +224,7 @@ const OmnidirectionalRing: React.FC<DirectionalRingProps> = ({
     color,
     opacity,
     rotation,
-    isSelected,
+    highlightProps,
     groupRef,
     ...props
 }) => {
@@ -240,7 +239,7 @@ const OmnidirectionalRing: React.FC<DirectionalRingProps> = ({
 
     return (
         <>
-            {isSelected && <Circle radius={radius} {...SELECTED_PROPS} />}
+            {highlightProps && <Circle radius={radius} {...highlightProps} />}
 
             <HideGroup opacity={opacity} ref={groupRef} rotation={rotation} {...props}>
                 <Circle radius={radius} fill="transparent" />
@@ -272,7 +271,7 @@ function renderRing(
     radius: number,
     rotation: number,
     groupRef: RefObject<Konva.Group | null>,
-    showHighlight: boolean,
+    highlightProps?: ShapeConfig,
 ) {
     switch (object.ring) {
         case EnemyRingStyle.NoDirection:
@@ -281,7 +280,7 @@ function renderRing(
                     radius={radius}
                     color={object.color}
                     opacity={object.opacity / 100}
-                    isSelected={showHighlight}
+                    highlightProps={highlightProps}
                 />
             );
 
@@ -292,7 +291,7 @@ function renderRing(
                     rotation={rotation}
                     color={object.color}
                     opacity={object.opacity / 100}
-                    isSelected={showHighlight}
+                    highlightProps={highlightProps}
                     groupRef={groupRef}
                 />
             );
@@ -304,7 +303,7 @@ function renderRing(
                     rotation={rotation}
                     color={object.color}
                     opacity={object.opacity / 100}
-                    isSelected={showHighlight}
+                    highlightProps={highlightProps}
                     groupRef={groupRef}
                 />
             );
@@ -312,7 +311,7 @@ function renderRing(
 }
 
 const EnemyRenderer: React.FC<EnemyRendererProps> = ({ object, radius, rotation, groupRef, isDragging }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const theme = useSceneTheme();
     const textConfig = getEnemyTextConfig(theme);
 
@@ -324,7 +323,7 @@ const EnemyRenderer: React.FC<EnemyRendererProps> = ({ object, radius, rotation,
                 <EnemyLabel name={object.name} radius={radius} color={object.color} {...textConfig} />
             </HideGroup>
 
-            {renderRing(object, radius, rotation, groupRef, showHighlight)}
+            {renderRing(object, radius, rotation, groupRef, highlightProps)}
         </>
     );
 };

--- a/src/prefabs/Markers.tsx
+++ b/src/prefabs/Markers.tsx
@@ -6,7 +6,7 @@ import { getDragOffset, registerDropHandler } from '../DropHandler';
 import { ALIGN_TO_PIXEL } from '../coord';
 import { DetailsItem } from '../panel/DetailsItem';
 import { ListComponentProps, registerListComponent } from '../panel/ListComponentRegistry';
-import { RendererProps, registerRenderer } from '../render/ObjectRegistry';
+import { registerRenderer, RendererProps } from '../render/ObjectRegistry';
 import { LayerName } from '../render/layers';
 import { MarkerObject, ObjectType } from '../scene';
 import {
@@ -15,7 +15,6 @@ import {
     COLOR_MARKER_RED,
     COLOR_MARKER_YELLOW,
     DEFAULT_MARKER_OPACITY,
-    SELECTED_PROPS,
 } from '../theme';
 import { useImageTracked } from '../useObjectLoading';
 import { usePanelDrag } from '../usePanelDrag';
@@ -23,7 +22,7 @@ import { makeDisplayName } from '../util';
 import { HideGroup } from './HideGroup';
 import { PrefabIcon } from './PrefabIcon';
 import { ResizeableObjectContainer } from './ResizeableObjectContainer';
-import { useShowHighlight } from './highlight';
+import { useHighlightProps } from './highlight';
 
 const DEFAULT_SIZE = 42;
 const ICON_RATIO = 32 / DEFAULT_SIZE;
@@ -96,7 +95,7 @@ interface OutlineProps {
     highlightWidth: number;
     highlightHeight: number;
     highlightOffset: number;
-    showHighlight: boolean;
+    highlightProps?: ShapeConfig;
     strokeProps: ShapeConfig;
     dashSize: number;
     opacity: number;
@@ -107,19 +106,19 @@ const EllipseOutline: React.FC<OutlineProps> = ({
     height,
     highlightWidth,
     highlightHeight,
-    showHighlight,
+    highlightProps,
     strokeProps,
     opacity,
 }) => {
     return (
         <>
-            {showHighlight && (
+            {highlightProps && (
                 <Ellipse
                     x={width / 2}
                     y={height / 2}
                     radiusX={highlightWidth / 2}
                     radiusY={highlightHeight / 2}
-                    {...SELECTED_PROPS}
+                    {...highlightProps}
                     opacity={0.25}
                 />
             )}
@@ -144,20 +143,20 @@ const RectangleOutline: React.FC<OutlineProps> = ({
     highlightWidth,
     highlightHeight,
     highlightOffset,
-    showHighlight,
+    highlightProps,
     strokeProps,
     dashSize,
     opacity,
 }) => {
     return (
         <>
-            {showHighlight && (
+            {highlightProps && (
                 <Rect
                     x={-highlightOffset / 2}
                     y={-highlightOffset / 2}
                     width={highlightWidth}
                     height={highlightHeight}
-                    {...SELECTED_PROPS}
+                    {...highlightProps}
                     {...ALIGN_TO_PIXEL}
                     opacity={0.25}
                 />
@@ -178,7 +177,7 @@ const RectangleOutline: React.FC<OutlineProps> = ({
 };
 
 const MarkerRenderer: React.FC<RendererProps<MarkerObject>> = ({ object }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const [image] = useImageTracked(object.image);
 
     const iconWidth = object.width * ICON_RATIO;
@@ -209,7 +208,7 @@ const MarkerRenderer: React.FC<RendererProps<MarkerObject>> = ({ object }) => {
                         <EllipseOutline
                             width={object.width}
                             height={object.height}
-                            showHighlight={showHighlight}
+                            highlightProps={highlightProps}
                             highlightWidth={highlightWidth}
                             highlightHeight={highlightHeight}
                             highlightOffset={highlightOffset}
@@ -222,7 +221,7 @@ const MarkerRenderer: React.FC<RendererProps<MarkerObject>> = ({ object }) => {
                         <RectangleOutline
                             width={object.width}
                             height={object.height}
-                            showHighlight={showHighlight}
+                            highlightProps={highlightProps}
                             highlightWidth={highlightWidth}
                             highlightHeight={highlightHeight}
                             highlightOffset={highlightOffset}

--- a/src/prefabs/Markers.tsx
+++ b/src/prefabs/Markers.tsx
@@ -6,7 +6,7 @@ import { getDragOffset, registerDropHandler } from '../DropHandler';
 import { ALIGN_TO_PIXEL } from '../coord';
 import { DetailsItem } from '../panel/DetailsItem';
 import { ListComponentProps, registerListComponent } from '../panel/ListComponentRegistry';
-import { registerRenderer, RendererProps } from '../render/ObjectRegistry';
+import { RendererProps, registerRenderer } from '../render/ObjectRegistry';
 import { LayerName } from '../render/layers';
 import { MarkerObject, ObjectType } from '../scene';
 import {

--- a/src/prefabs/Party.tsx
+++ b/src/prefabs/Party.tsx
@@ -7,12 +7,12 @@ import { ListComponentProps, registerListComponent } from '../panel/ListComponen
 import { LayerName } from '../render/layers';
 import { registerRenderer, RendererProps } from '../render/ObjectRegistry';
 import { ObjectType, PartyObject } from '../scene';
-import { DEFAULT_PARTY_OPACITY, SELECTED_PROPS } from '../theme';
+import { DEFAULT_PARTY_OPACITY } from '../theme';
 import { useImageTracked } from '../useObjectLoading';
 import { usePanelDrag } from '../usePanelDrag';
 import { makeDisplayName } from '../util';
 import { HideGroup } from './HideGroup';
-import { useShowHighlight } from './highlight';
+import { useHighlightProps } from './highlight';
 import { PrefabIcon } from './PrefabIcon';
 import { ResizeableObjectContainer } from './ResizeableObjectContainer';
 
@@ -66,19 +66,19 @@ registerDropHandler<PartyObject>(ObjectType.Party, (object, position) => {
 });
 
 const PartyRenderer: React.FC<RendererProps<PartyObject>> = ({ object }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const [image] = useImageTracked(object.image);
 
     return (
         <ResizeableObjectContainer object={object} transformerProps={{ centeredScaling: true }}>
             {(groupProps) => (
                 <Group {...groupProps}>
-                    {showHighlight && (
+                    {highlightProps && (
                         <Rect
                             width={object.width}
                             height={object.height}
                             cornerRadius={(object.width + object.height) / 2 / 5}
-                            {...SELECTED_PROPS}
+                            {...highlightProps}
                         />
                     )}
                     <HideGroup>

--- a/src/prefabs/StatusIcon.tsx
+++ b/src/prefabs/StatusIcon.tsx
@@ -8,13 +8,13 @@ import { ListComponentProps, registerListComponent } from '../panel/ListComponen
 import { RendererProps, registerRenderer } from '../render/ObjectRegistry';
 import { LayerName } from '../render/layers';
 import { IconObject, ObjectType } from '../scene';
-import { DEFAULT_IMAGE_OPACITY, SELECTED_PROPS } from '../theme';
+import { DEFAULT_IMAGE_OPACITY } from '../theme';
 import { useImageTracked } from '../useObjectLoading';
 import { usePanelDrag } from '../usePanelDrag';
 import { HideGroup } from './HideGroup';
 import { PrefabIcon } from './PrefabIcon';
 import { ResizeableObjectContainer } from './ResizeableObjectContainer';
-import { useShowHighlight } from './highlight';
+import { useHighlightProps } from './highlight';
 
 const DEFAULT_SIZE = 32;
 
@@ -86,19 +86,19 @@ const IconTimer: React.FC<IconTimerProps> = ({ time, width, height }) => {
 };
 
 const IconRenderer: React.FC<RendererProps<IconObject>> = ({ object }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const [image] = useImageTracked(object.image);
 
     return (
         <ResizeableObjectContainer object={object} transformerProps={{ centeredScaling: true }}>
             {(groupProps) => (
                 <Group {...groupProps}>
-                    {showHighlight && (
+                    {highlightProps && (
                         <Rect
                             width={object.width}
                             height={object.height}
                             cornerRadius={(object.width + object.height) / 2 / 5}
-                            {...SELECTED_PROPS}
+                            {...highlightProps}
                         />
                     )}
                     <HideGroup>

--- a/src/prefabs/TextLabel.tsx
+++ b/src/prefabs/TextLabel.tsx
@@ -11,7 +11,7 @@ import { RendererProps, registerRenderer } from '../render/ObjectRegistry';
 import { ActivePortal } from '../render/Portals';
 import { LayerName } from '../render/layers';
 import { ObjectType, TextObject } from '../scene';
-import { SELECTED_PROPS, useSceneTheme } from '../theme';
+import { useSceneTheme } from '../theme';
 import { useKonvaCache } from '../useKonvaCache';
 import { usePanelDrag } from '../usePanelDrag';
 import { clamp } from '../util';
@@ -20,7 +20,7 @@ import { DraggableObject } from './DraggableObject';
 import { HideCutoutGroup } from './HideGroup';
 import { PrefabIcon } from './PrefabIcon';
 import { GroupProps } from './ResizeableObjectContainer';
-import { useShowHighlight, useShowResizer } from './highlight';
+import { useHighlightProps, useShowResizer } from './highlight';
 
 const DEFAULT_TEXT = 'Text';
 const DEFAULT_TEXT_ALIGN = 'center';
@@ -173,7 +173,7 @@ const TextContainer: React.FC<TextContainerProps> = ({ object, cacheKey, childre
 };
 
 const TextRenderer: React.FC<RendererProps<TextObject>> = ({ object }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
 
     const [measuredFontSize, setMeasuredFontSize] = useState(object.fontSize);
     const [size, setSize] = useState({ width: 0, height: 0 });
@@ -188,15 +188,15 @@ const TextRenderer: React.FC<RendererProps<TextObject>> = ({ object }) => {
     }, [textRef, object.text, object.fontSize]);
 
     const [prevSize, setPrevSize] = useState(size);
-    const [prevShowHighlight, setPrevShowHighlight] = useState(showHighlight);
+    const [prevShowHighlight, setPrevShowHighlight] = useState(!!highlightProps);
     const [prevMeasuredFontSize, setPrevMeasuredFontSize] = useState(measuredFontSize);
 
     if (size !== prevSize) {
         setPrevSize(size);
         setCacheKey(cacheKey + 1);
     }
-    if (showHighlight !== prevShowHighlight) {
-        setPrevShowHighlight(showHighlight);
+    if (!!highlightProps !== prevShowHighlight) {
+        setPrevShowHighlight(!!highlightProps);
         setCacheKey(cacheKey + 1);
     }
     if (measuredFontSize !== prevMeasuredFontSize) {
@@ -205,7 +205,7 @@ const TextRenderer: React.FC<RendererProps<TextObject>> = ({ object }) => {
     }
 
     const strokeWidth = object.style === 'outline' ? Math.ceil(clamp(measuredFontSize / 15, 2, 8)) : 0;
-    const highlightStrokeWidth = (SELECTED_PROPS.strokeWidth ?? 0) + strokeWidth;
+    const highlightStrokeWidth = (highlightProps?.strokeWidth ?? 0) + strokeWidth;
 
     const shadow: ShapeConfig =
         object.style === 'shadow'
@@ -222,7 +222,7 @@ const TextRenderer: React.FC<RendererProps<TextObject>> = ({ object }) => {
             <TextContainer object={object} cacheKey={cacheKey}>
                 {(groupProps) => (
                     <Group {...groupProps} offsetX={size.width / 2} offsetY={size.height / 2}>
-                        {showHighlight && (
+                        {highlightProps && (
                             <Text
                                 text={object.text}
                                 width={size.width}
@@ -231,13 +231,13 @@ const TextRenderer: React.FC<RendererProps<TextObject>> = ({ object }) => {
                                 verticalAlign="middle"
                                 fontSize={measuredFontSize}
                                 lineHeight={LINE_HEIGHT}
-                                {...SELECTED_PROPS}
+                                {...highlightProps}
                                 strokeWidth={highlightStrokeWidth}
                             />
                         )}
 
                         <HideCutoutGroup>
-                            <CompositeReplaceGroup enabled={showHighlight} opacity={object.opacity / 100}>
+                            <CompositeReplaceGroup enabled={!!highlightProps} opacity={object.opacity / 100}>
                                 <Text
                                     text={object.text}
                                     width={size.width}

--- a/src/prefabs/highlight.ts
+++ b/src/prefabs/highlight.ts
@@ -1,28 +1,36 @@
+import { ShapeConfig } from 'konva/lib/Shape';
 import { EditMode } from '../editMode';
 import { isMoveable, UnknownObject } from '../scene';
-import { useSelection } from '../selection';
+import { useSelection, useSpotlight } from '../selection';
 import { SceneSelection } from '../SelectionContext';
+import { SELECTED_PROPS, SPOTLIGHT_PROPS } from '../theme';
 import { useEditMode } from '../useEditMode';
 
-function isPinned(object: UnknownObject) {
-    if (isMoveable(object)) {
-        return object.pinned ?? false;
-    }
-    return false;
+function shouldShowResizer(object: UnknownObject, selection: SceneSelection, editMode: EditMode) {
+    return (
+        selection.size === 1 &&
+        selection.has(object.id) &&
+        editMode === EditMode.Normal &&
+        isMoveable(object) &&
+        !object.pinned
+    );
 }
 
-function isResizeable(object: UnknownObject, selection: SceneSelection, editMode: EditMode) {
-    return selection.size === 1 && editMode === EditMode.Normal && !isPinned(object);
-}
-
-export function useShowHighlight(object: UnknownObject): boolean {
+export function useHighlightProps(object: UnknownObject): ShapeConfig | undefined {
     const [editMode] = useEditMode();
     const [selection] = useSelection();
-    return selection.has(object.id) && !isResizeable(object, selection, editMode);
+    const [spotlight] = useSpotlight();
+
+    // Regular selection styling takes precedence if it's the only selected object.
+    if (spotlight.has(object.id) && !(selection.size === 1 && selection.has(object.id))) {
+        return SPOTLIGHT_PROPS;
+    }
+
+    return selection.has(object.id) && !shouldShowResizer(object, selection, editMode) ? SELECTED_PROPS : undefined;
 }
 
 export function useShowResizer(object: UnknownObject): boolean {
     const [editMode] = useEditMode();
     const [selection] = useSelection();
-    return selection.has(object.id) && isResizeable(object, selection, editMode);
+    return shouldShowResizer(object, selection, editMode);
 }

--- a/src/prefabs/zone/ZoneArc.tsx
+++ b/src/prefabs/zone/ZoneArc.tsx
@@ -12,7 +12,7 @@ import { RendererProps, registerRenderer } from '../../render/ObjectRegistry';
 import { ActivePortal } from '../../render/Portals';
 import { LayerName } from '../../render/layers';
 import { ArcZone, ObjectType } from '../../scene';
-import { CENTER_DOT_RADIUS, DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, SELECTED_PROPS, panelVars } from '../../theme';
+import { CENTER_DOT_RADIUS, DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { usePanelDrag } from '../../usePanelDrag';
 import { clamp, degtorad, mod360 } from '../../util';
 import { VEC_ZERO, distance, getIntersectionDistance, vecAtAngle, vecNormal } from '../../vector';
@@ -21,7 +21,7 @@ import { DraggableObject } from '../DraggableObject';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
 import { MAX_CONE_ANGLE, MIN_CONE_ANGLE, MIN_RADIUS } from '../bounds';
-import { useShowHighlight, useShowResizer } from '../highlight';
+import { useHighlightProps, useShowResizer } from '../highlight';
 import { getZoneStyle } from './style';
 
 const NAME = 'Arc';
@@ -138,7 +138,7 @@ const ArcRenderer: React.FC<ArcRendererProps> = ({
     coneAngle,
     isDragging,
 }) => {
-    const isSelected = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const style = getZoneStyle(object.color, object.opacity, outerRadius * 2, object.hollow);
 
     const highlightInnerRadius = Math.min(outerRadius, innerRadius);
@@ -146,13 +146,13 @@ const ArcRenderer: React.FC<ArcRendererProps> = ({
 
     return (
         <Group rotation={rotation - 90 - coneAngle / 2}>
-            {isSelected && (
+            {highlightProps && (
                 <OffsetArc
                     outerRadius={highlightOuterRadius}
                     innerRadius={highlightInnerRadius}
                     angle={coneAngle}
                     shapeOffset={style.strokeWidth / 2}
-                    {...SELECTED_PROPS}
+                    {...highlightProps}
                 />
             )}
             <HideGroup>

--- a/src/prefabs/zone/ZoneCircle.tsx
+++ b/src/prefabs/zone/ZoneCircle.tsx
@@ -7,12 +7,12 @@ import { ListComponentProps, registerListComponent } from '../../panel/ListCompo
 import { registerRenderer, RendererProps } from '../../render/ObjectRegistry';
 import { LayerName } from '../../render/layers';
 import { CircleZone, ObjectType } from '../../scene';
-import { CENTER_DOT_RADIUS, DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars, SELECTED_PROPS } from '../../theme';
+import { CENTER_DOT_RADIUS, DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { usePanelDrag } from '../../usePanelDrag';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
 import { RadiusObjectContainer } from '../RadiusObjectContainer';
-import { useShowHighlight } from '../highlight';
+import { useHighlightProps } from '../highlight';
 import { getZoneStyle } from './style';
 
 const NAME = 'Circle';
@@ -59,12 +59,12 @@ interface CircleRendererProps extends RendererProps<CircleZone> {
 }
 
 const CircleRenderer: React.FC<CircleRendererProps> = ({ object, radius, isDragging }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const style = getZoneStyle(object.color, object.opacity, radius * 2, object.hollow);
 
     return (
         <>
-            {showHighlight && <Circle radius={radius + style.strokeWidth / 2} {...SELECTED_PROPS} />}
+            {highlightProps && <Circle radius={radius + style.strokeWidth / 2} {...highlightProps} />}
 
             <HideGroup>
                 <Circle radius={radius} {...style} />

--- a/src/prefabs/zone/ZoneCone.tsx
+++ b/src/prefabs/zone/ZoneCone.tsx
@@ -12,7 +12,7 @@ import { RendererProps, registerRenderer } from '../../render/ObjectRegistry';
 import { ActivePortal } from '../../render/Portals';
 import { LayerName } from '../../render/layers';
 import { ConeZone, ObjectType } from '../../scene';
-import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, SELECTED_PROPS, panelVars } from '../../theme';
+import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { usePanelDrag } from '../../usePanelDrag';
 import { clamp, degtorad, mod360 } from '../../util';
 import { distance } from '../../vector';
@@ -21,7 +21,7 @@ import { DraggableObject } from '../DraggableObject';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
 import { MAX_CONE_ANGLE, MIN_CONE_ANGLE, MIN_RADIUS } from '../bounds';
-import { useShowHighlight, useShowResizer } from '../highlight';
+import { useHighlightProps, useShowResizer } from '../highlight';
 import { getZoneStyle } from './style';
 
 const NAME = 'Cone';
@@ -123,17 +123,17 @@ interface ConeRendererProps extends RendererProps<ConeZone> {
 }
 
 const ConeRenderer: React.FC<ConeRendererProps> = ({ object, radius, rotation, coneAngle }) => {
-    const isSelected = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const style = getZoneStyle(object.color, object.opacity, radius * 2, object.hollow);
 
     return (
         <Group rotation={rotation - 90 - coneAngle / 2}>
-            {isSelected && (
+            {highlightProps && (
                 <OffsetWedge
                     radius={radius}
                     angle={coneAngle}
                     shapeOffset={style.strokeWidth / 2}
-                    {...SELECTED_PROPS}
+                    {...highlightProps}
                 />
             )}
             <HideGroup>

--- a/src/prefabs/zone/ZoneDonut.tsx
+++ b/src/prefabs/zone/ZoneDonut.tsx
@@ -7,10 +7,10 @@ import { ListComponentProps, registerListComponent } from '../../panel/ListCompo
 import { LayerName } from '../../render/layers';
 import { registerRenderer, RendererProps } from '../../render/ObjectRegistry';
 import { DonutZone, ObjectType } from '../../scene';
-import { CENTER_DOT_RADIUS, DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars, SELECTED_PROPS } from '../../theme';
+import { CENTER_DOT_RADIUS, DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { usePanelDrag } from '../../usePanelDrag';
 import { HideGroup } from '../HideGroup';
-import { useShowHighlight } from '../highlight';
+import { useHighlightProps } from '../highlight';
 import { PrefabIcon } from '../PrefabIcon';
 import { RadiusObjectContainer } from '../RadiusObjectContainer';
 import { getZoneStyle } from './style';
@@ -62,7 +62,7 @@ interface DonutRendererProps extends RendererProps<DonutZone> {
 }
 
 const DonutRenderer: React.FC<DonutRendererProps> = ({ object, radius, innerRadius, isDragging }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const style = getZoneStyle(object.color, object.opacity, radius * 2);
 
     const highlightInnerRadius = Math.min(radius, innerRadius);
@@ -70,11 +70,11 @@ const DonutRenderer: React.FC<DonutRendererProps> = ({ object, radius, innerRadi
 
     return (
         <>
-            {showHighlight && (
+            {highlightProps && (
                 <Ring
                     innerRadius={highlightInnerRadius - style.strokeWidth / 2}
                     outerRadius={highlightOuterRadius + style.strokeWidth / 2}
-                    {...SELECTED_PROPS}
+                    {...highlightProps}
                 />
             )}
             <HideGroup>

--- a/src/prefabs/zone/ZoneExaflare.tsx
+++ b/src/prefabs/zone/ZoneExaflare.tsx
@@ -8,10 +8,10 @@ import { ListComponentProps, registerListComponent } from '../../panel/ListCompo
 import { LayerName } from '../../render/layers';
 import { registerRenderer, RendererProps } from '../../render/ObjectRegistry';
 import { ExaflareZone, ObjectType } from '../../scene';
-import { CENTER_DOT_RADIUS, DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars, SELECTED_PROPS } from '../../theme';
+import { CENTER_DOT_RADIUS, DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { usePanelDrag } from '../../usePanelDrag';
 import { HideGroup } from '../HideGroup';
-import { useShowHighlight } from '../highlight';
+import { useHighlightProps } from '../highlight';
 import { PrefabIcon } from '../PrefabIcon';
 import { RadiusObjectContainer } from '../RadiusObjectContainer';
 import { EXAFLARE_SPACING_DEFAULT } from './constants';
@@ -81,7 +81,7 @@ interface ExaflareRendererProps extends RendererProps<ExaflareZone> {
 }
 
 const ExaflareRenderer: React.FC<ExaflareRendererProps> = ({ object, radius, rotation, isDragging }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const style = getZoneStyle(object.color, object.opacity, radius * 2);
 
     const arrow = getArrowStyle(object.color, object.opacity * 3);
@@ -107,7 +107,7 @@ const ExaflareRenderer: React.FC<ExaflareRendererProps> = ({ object, radius, rot
                     ))}
                 </HideGroup>
 
-                {showHighlight && <Circle radius={radius + style.strokeWidth / 2} {...SELECTED_PROPS} />}
+                {highlightProps && <Circle radius={radius + style.strokeWidth / 2} {...highlightProps} />}
 
                 <HideGroup>
                     <Circle radius={radius} {...style} />

--- a/src/prefabs/zone/ZoneEye.tsx
+++ b/src/prefabs/zone/ZoneEye.tsx
@@ -10,13 +10,13 @@ import { ListComponentProps, registerListComponent } from '../../panel/ListCompo
 import { registerRenderer, RendererProps } from '../../render/ObjectRegistry';
 import { LayerName } from '../../render/layers';
 import { EyeObject, ObjectType } from '../../scene';
-import { panelVars, SELECTED_PROPS } from '../../theme';
+import { panelVars } from '../../theme';
 import { useKonvaCache } from '../../useKonvaCache';
 import { usePanelDrag } from '../../usePanelDrag';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
 import { RadiusObjectContainer } from '../RadiusObjectContainer';
-import { useShowHighlight } from '../highlight';
+import { useHighlightProps } from '../highlight';
 
 const DEFAULT_RADIUS = 25;
 const DEFAULT_OPACITY = 100;
@@ -126,7 +126,7 @@ interface EyeRendererProps extends RendererProps<EyeObject> {
 }
 
 const EyeRenderer: React.FC<EyeRendererProps> = ({ object, radius, groupRef }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const scale = radius / 20;
     const eyeStyle: ShapeConfig = {
         fillRadialGradientColorStops: getEyeGradient(object.color, object.invert),
@@ -143,14 +143,14 @@ const EyeRenderer: React.FC<EyeRendererProps> = ({ object, radius, groupRef }) =
     const highlightColor = getHighlightColor(object.color);
 
     // Cache so overlapping shapes with opacity appear as one object.
-    useKonvaCache(groupRef, [object.color, object.opacity, radius, showHighlight]);
+    useKonvaCache(groupRef, [object.color, object.opacity, radius, highlightProps]);
 
     return (
         <>
             <Group opacity={object.opacity / 100} ref={groupRef}>
                 <Group scaleX={scale} scaleY={scale}>
-                    {showHighlight && (
-                        <Path data={OUTER_EYE_PATH} scaleX={21 / 20} scaleY={22 / 20} {...SELECTED_PROPS} />
+                    {highlightProps && (
+                        <Path data={OUTER_EYE_PATH} scaleX={21 / 20} scaleY={22 / 20} {...highlightProps} />
                     )}
 
                     <HideGroup>

--- a/src/prefabs/zone/ZoneKnockback.tsx
+++ b/src/prefabs/zone/ZoneKnockback.tsx
@@ -7,12 +7,12 @@ import { ListComponentProps, registerListComponent } from '../../panel/ListCompo
 import { registerRenderer, RendererProps } from '../../render/ObjectRegistry';
 import { LayerName } from '../../render/layers';
 import { CircleZone, ObjectType } from '../../scene';
-import { CENTER_DOT_RADIUS, DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars, SELECTED_PROPS } from '../../theme';
+import { CENTER_DOT_RADIUS, DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { usePanelDrag } from '../../usePanelDrag';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
 import { RadiusObjectContainer } from '../RadiusObjectContainer';
-import { useShowHighlight } from '../highlight';
+import { useHighlightProps } from '../highlight';
 import { ChevronTail } from './shapes';
 import { getArrowStyle, getZoneStyle } from './style';
 
@@ -59,7 +59,7 @@ interface KnockbackRendererProps extends RendererProps<CircleZone> {
 }
 
 const KnockbackRenderer: React.FC<KnockbackRendererProps> = ({ object, radius, isDragging }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const ring = getZoneStyle(object.color, object.opacity, radius * 2);
     const arrow = getArrowStyle(object.color, object.opacity * 3);
 
@@ -70,7 +70,7 @@ const KnockbackRenderer: React.FC<KnockbackRendererProps> = ({ object, radius, i
 
     return (
         <>
-            {showHighlight && <Circle radius={radius + ring.strokeWidth / 2} {...SELECTED_PROPS} />}
+            {highlightProps && <Circle radius={radius + ring.strokeWidth / 2} {...highlightProps} />}
 
             <HideGroup>
                 <Circle radius={radius} {...ring} strokeEnabled={false} opacity={0.5} />

--- a/src/prefabs/zone/ZoneLine.tsx
+++ b/src/prefabs/zone/ZoneLine.tsx
@@ -11,14 +11,14 @@ import { registerRenderer, RendererProps } from '../../render/ObjectRegistry';
 import { ActivePortal } from '../../render/Portals';
 import { LineZone, ObjectType } from '../../scene';
 import { useScene } from '../../SceneProvider';
-import { CENTER_DOT_RADIUS, DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars, SELECTED_PROPS } from '../../theme';
+import { CENTER_DOT_RADIUS, DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { usePanelDrag } from '../../usePanelDrag';
 import { distance, getDistanceFromLine, VEC_ZERO, vecAtAngle } from '../../vector';
 import { MIN_LINE_LENGTH, MIN_LINE_WIDTH } from '../bounds';
 import { CONTROL_POINT_BORDER_COLOR, createControlPointManager, HandleFuncProps, HandleStyle } from '../ControlPoint';
 import { DraggableObject } from '../DraggableObject';
 import { HideGroup } from '../HideGroup';
-import { useShowHighlight, useShowResizer } from '../highlight';
+import { useHighlightProps, useShowResizer } from '../highlight';
 import { PrefabIcon } from '../PrefabIcon';
 import { getZoneStyle } from './style';
 
@@ -179,7 +179,7 @@ interface LineRendererProps extends RendererProps<LineZone> {
 }
 
 const LineRenderer: React.FC<LineRendererProps> = ({ object, length, width, rotation, isDragging }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const style = getZoneStyle(object.color, object.opacity, Math.min(length, width), object.hollow);
 
     const x = -width / 2;
@@ -190,7 +190,7 @@ const LineRenderer: React.FC<LineRendererProps> = ({ object, length, width, rota
 
     return (
         <Group rotation={rotation}>
-            {showHighlight && (
+            {highlightProps && (
                 <Rect
                     x={x}
                     y={y}
@@ -198,7 +198,7 @@ const LineRenderer: React.FC<LineRendererProps> = ({ object, length, width, rota
                     height={highlightLength}
                     offsetX={highlightOffset / 2}
                     offsetY={highlightOffset / 2}
-                    {...SELECTED_PROPS}
+                    {...highlightProps}
                 />
             )}
             <HideGroup>

--- a/src/prefabs/zone/ZoneLineKnockAway.tsx
+++ b/src/prefabs/zone/ZoneLineKnockAway.tsx
@@ -8,12 +8,12 @@ import { ListComponentProps, registerListComponent } from '../../panel/ListCompo
 import { registerRenderer, RendererProps } from '../../render/ObjectRegistry';
 import { LayerName } from '../../render/layers';
 import { ObjectType, RectangleZone } from '../../scene';
-import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars, SELECTED_PROPS } from '../../theme';
+import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { usePanelDrag } from '../../usePanelDrag';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
 import { ResizeableObjectContainer } from '../ResizeableObjectContainer';
-import { useShowHighlight } from '../highlight';
+import { useHighlightProps } from '../highlight';
 import { ChevronConfig, ChevronTail } from './shapes';
 import { getArrowStyle, getZoneStyle } from './style';
 
@@ -66,7 +66,7 @@ const ARROW_HEIGHT_FRAC = 3 / 5;
 const ARROW_PAD = 0.08;
 
 const LineKnockAwayRenderer: React.FC<RendererProps<RectangleZone>> = ({ object }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const [pattern, setPattern] = useState<HTMLImageElement>();
     const style = getZoneStyle(object.color, object.opacity, Math.min(object.width, object.height));
     const { fill, ...stroke } = style;
@@ -107,13 +107,13 @@ const LineKnockAwayRenderer: React.FC<RendererProps<RectangleZone>> = ({ object 
             <ResizeableObjectContainer object={object} transformerProps={{ keepRatio: false }}>
                 {(groupProps) => (
                     <Group {...groupProps}>
-                        {showHighlight && (
+                        {highlightProps && (
                             <Rect
                                 offsetX={highlightOffset / 2}
                                 offsetY={highlightOffset / 2}
                                 width={highlightWidth}
                                 height={highlightHeight}
-                                {...SELECTED_PROPS}
+                                {...highlightProps}
                             />
                         )}
                         <HideGroup>

--- a/src/prefabs/zone/ZoneLineKnockback.tsx
+++ b/src/prefabs/zone/ZoneLineKnockback.tsx
@@ -8,12 +8,12 @@ import { ListComponentProps, registerListComponent } from '../../panel/ListCompo
 import { registerRenderer, RendererProps } from '../../render/ObjectRegistry';
 import { LayerName } from '../../render/layers';
 import { ObjectType, RectangleZone } from '../../scene';
-import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars, SELECTED_PROPS } from '../../theme';
+import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { usePanelDrag } from '../../usePanelDrag';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
 import { ResizeableObjectContainer } from '../ResizeableObjectContainer';
-import { useShowHighlight } from '../highlight';
+import { useHighlightProps } from '../highlight';
 import { ChevronTail } from './shapes';
 import { getArrowStyle, getZoneStyle } from './style';
 
@@ -66,7 +66,7 @@ const ARROW_W = 25;
 const ARROW_H = 15;
 
 const LineKnockbackRenderer: React.FC<RendererProps<RectangleZone>> = ({ object }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const [pattern, setPattern] = useState<HTMLImageElement>();
     const style = getZoneStyle(object.color, object.opacity, Math.min(object.width, object.height));
 
@@ -94,13 +94,13 @@ const LineKnockbackRenderer: React.FC<RendererProps<RectangleZone>> = ({ object 
             <ResizeableObjectContainer object={object} transformerProps={{ keepRatio: false }}>
                 {(groupProps) => (
                     <Group {...groupProps}>
-                        {showHighlight && (
+                        {highlightProps && (
                             <Rect
                                 offsetX={highlightOffset / 2}
                                 offsetY={highlightOffset / 2}
                                 width={highlightWidth}
                                 height={highlightHeight}
-                                {...SELECTED_PROPS}
+                                {...highlightProps}
                             />
                         )}
                         <HideGroup>

--- a/src/prefabs/zone/ZoneLineStack.tsx
+++ b/src/prefabs/zone/ZoneLineStack.tsx
@@ -8,12 +8,12 @@ import { ListComponentProps, registerListComponent } from '../../panel/ListCompo
 import { registerRenderer, RendererProps } from '../../render/ObjectRegistry';
 import { LayerName } from '../../render/layers';
 import { ObjectType, RectangleZone } from '../../scene';
-import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars, SELECTED_PROPS } from '../../theme';
+import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { usePanelDrag } from '../../usePanelDrag';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
 import { ResizeableObjectContainer } from '../ResizeableObjectContainer';
-import { useShowHighlight } from '../highlight';
+import { useHighlightProps } from '../highlight';
 import { ChevronConfig, ChevronTail } from './shapes';
 import { getArrowStyle } from './style';
 
@@ -70,7 +70,7 @@ const ARROW_HEIGHT_FRAC = 3 / 5;
 const ARROW_PAD = 0.3;
 
 const LineStackRenderer: React.FC<RendererProps<RectangleZone>> = ({ object }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const [pattern, setPattern] = useState<HTMLImageElement>();
 
     const patternWidth = object.width;
@@ -104,8 +104,8 @@ const LineStackRenderer: React.FC<RendererProps<RectangleZone>> = ({ object }) =
             <ResizeableObjectContainer object={object} transformerProps={{ centeredScaling: true, keepRatio: false }}>
                 {(groupProps) => (
                     <Group {...groupProps}>
-                        {showHighlight && (
-                            <Rect width={object.width} height={object.height} {...SELECTED_PROPS} opacity={0.25} />
+                        {highlightProps && (
+                            <Rect width={object.width} height={object.height} {...highlightProps} opacity={0.25} />
                         )}
                         <HideGroup>
                             <Rect

--- a/src/prefabs/zone/ZonePolygon.tsx
+++ b/src/prefabs/zone/ZonePolygon.tsx
@@ -12,12 +12,12 @@ import { ListComponentProps, registerListComponent } from '../../panel/ListCompo
 import { registerRenderer, RendererProps } from '../../render/ObjectRegistry';
 import { LayerName } from '../../render/layers';
 import { ObjectType, PolygonZone } from '../../scene';
-import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars, SELECTED_PROPS } from '../../theme';
+import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { usePanelDrag } from '../../usePanelDrag';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
 import { RadiusObjectContainer } from '../RadiusObjectContainer';
-import { useShowHighlight } from '../highlight';
+import { useHighlightProps } from '../highlight';
 import { getZoneStyle } from './style';
 
 const NAME = 'Regular Polygon';
@@ -67,19 +67,19 @@ interface PolygonRendererProps extends RendererProps<PolygonZone> {
 }
 
 const PolygonRenderer: React.FC<PolygonRendererProps> = ({ object, radius, rotation }) => {
-    const isSelected = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const style = getZoneStyle(object.color, object.opacity, radius * 2, object.hollow);
 
     const orientRotation = object.orient === 'side' ? 180 / object.sides : 0;
 
     return (
         <Group rotation={rotation + orientRotation}>
-            {isSelected && (
+            {highlightProps && (
                 <RegularPolygon
                     radius={radius + style.strokeWidth / 2}
                     sides={object.sides}
                     {...style}
-                    {...SELECTED_PROPS}
+                    {...highlightProps}
                 />
             )}
             <HideGroup>

--- a/src/prefabs/zone/ZoneProximity.tsx
+++ b/src/prefabs/zone/ZoneProximity.tsx
@@ -9,13 +9,13 @@ import { ListComponentProps, registerListComponent } from '../../panel/ListCompo
 import { registerRenderer, RendererProps } from '../../render/ObjectRegistry';
 import { LayerName } from '../../render/layers';
 import { CircleZone, ObjectType } from '../../scene';
-import { COLOR_BLUE_WHITE, DEFAULT_AOE_OPACITY, panelVars, SELECTED_PROPS } from '../../theme';
+import { COLOR_BLUE_WHITE, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { usePanelDrag } from '../../usePanelDrag';
 import { degtorad } from '../../util';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
 import { RadiusObjectContainer } from '../RadiusObjectContainer';
-import { useShowHighlight } from '../highlight';
+import { useHighlightProps } from '../highlight';
 import { getArrowStyle, getShadowColor } from './style';
 
 const DEFAULT_RADIUS = 200;
@@ -139,7 +139,7 @@ interface ProximityRendererProps extends RendererProps<CircleZone> {
 }
 
 const ProximityRenderer: React.FC<ProximityRendererProps> = ({ object, radius }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const gradient: ShapeConfig = {
         fillRadialGradientColorStops: getGradient(object.color, object.opacity),
         fillRadialGradientStartRadius: 0,
@@ -152,7 +152,7 @@ const ProximityRenderer: React.FC<ProximityRendererProps> = ({ object, radius })
 
     return (
         <>
-            {showHighlight && <Circle radius={radius} {...SELECTED_PROPS} opacity={0.25} />}
+            {highlightProps && <Circle radius={radius} {...highlightProps} opacity={0.25} />}
 
             <HideGroup>
                 <Circle radius={radius} {...gradient} />

--- a/src/prefabs/zone/ZoneRectangle.tsx
+++ b/src/prefabs/zone/ZoneRectangle.tsx
@@ -7,12 +7,12 @@ import { ListComponentProps, registerListComponent } from '../../panel/ListCompo
 import { registerRenderer, RendererProps } from '../../render/ObjectRegistry';
 import { LayerName } from '../../render/layers';
 import { ObjectType, RectangleZone } from '../../scene';
-import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars, SELECTED_PROPS } from '../../theme';
+import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { usePanelDrag } from '../../usePanelDrag';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
 import { ResizeableObjectContainer } from '../ResizeableObjectContainer';
-import { useShowHighlight } from '../highlight';
+import { useHighlightProps } from '../highlight';
 import { getZoneStyle } from './style';
 
 const NAME = 'Rectangle';
@@ -57,7 +57,7 @@ registerDropHandler<RectangleZone>(ObjectType.Rect, (object, position) => {
 });
 
 const RectangleRenderer: React.FC<RendererProps<RectangleZone>> = ({ object }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
 
     const style = getZoneStyle(object.color, object.opacity, Math.min(object.width, object.height), object.hollow);
 
@@ -69,13 +69,13 @@ const RectangleRenderer: React.FC<RendererProps<RectangleZone>> = ({ object }) =
         <ResizeableObjectContainer object={object} transformerProps={{ keepRatio: false }}>
             {(groupProps) => (
                 <Group {...groupProps}>
-                    {showHighlight && (
+                    {highlightProps && (
                         <Rect
                             offsetX={highlightOffset / 2}
                             offsetY={highlightOffset / 2}
                             width={highlightWidth}
                             height={highlightHeight}
-                            {...SELECTED_PROPS}
+                            {...highlightProps}
                         />
                     )}
                     <HideGroup>

--- a/src/prefabs/zone/ZoneRightTriangle.tsx
+++ b/src/prefabs/zone/ZoneRightTriangle.tsx
@@ -8,12 +8,12 @@ import { ListComponentProps, registerListComponent } from '../../panel/ListCompo
 import { registerRenderer, RendererProps } from '../../render/ObjectRegistry';
 import { LayerName } from '../../render/layers';
 import { ObjectType, RectangleZone } from '../../scene';
-import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars, SELECTED_PROPS } from '../../theme';
+import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { usePanelDrag } from '../../usePanelDrag';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
 import { ResizeableObjectContainer } from '../ResizeableObjectContainer';
-import { useShowHighlight } from '../highlight';
+import { useHighlightProps } from '../highlight';
 import { getZoneStyle } from './style';
 
 const NAME = 'Right triangle';
@@ -71,7 +71,7 @@ const RightTriangle: React.FC<RectConfig> = ({ width, height, ...props }) => {
 };
 
 const RightTriangleRenderer: React.FC<RendererProps<RectangleZone>> = ({ object }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const style = getZoneStyle(object.color, object.opacity, Math.min(object.width, object.height), object.hollow);
 
     const highlightOffset = style.strokeWidth;
@@ -82,13 +82,13 @@ const RightTriangleRenderer: React.FC<RendererProps<RectangleZone>> = ({ object 
         <ResizeableObjectContainer object={object}>
             {(groupProps) => (
                 <Group {...groupProps}>
-                    {showHighlight && (
+                    {highlightProps && (
                         <RightTriangle
                             offsetX={highlightOffset / 2}
                             offsetY={highlightOffset / 2}
                             width={highlightWidth}
                             height={highlightHeight}
-                            {...SELECTED_PROPS}
+                            {...highlightProps}
                         />
                     )}
                     <HideGroup>

--- a/src/prefabs/zone/ZoneRotate.tsx
+++ b/src/prefabs/zone/ZoneRotate.tsx
@@ -10,13 +10,13 @@ import { ListComponentProps, registerListComponent } from '../../panel/ListCompo
 import { registerRenderer, RendererProps } from '../../render/ObjectRegistry';
 import { LayerName } from '../../render/layers';
 import { CircleZone, ObjectType } from '../../scene';
-import { CENTER_DOT_RADIUS, panelVars, SELECTED_PROPS } from '../../theme';
+import { CENTER_DOT_RADIUS, panelVars } from '../../theme';
 import { useKonvaCache } from '../../useKonvaCache';
 import { usePanelDrag } from '../../usePanelDrag';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
 import { RadiusObjectContainer } from '../RadiusObjectContainer';
-import { useShowHighlight } from '../highlight';
+import { useHighlightProps } from '../highlight';
 import { getArrowStyle, getShadowColor, getZoneStyle } from './style';
 
 const DEFAULT_RADIUS = 25;
@@ -92,7 +92,7 @@ interface RotateRendererProps extends RendererProps<CircleZone> {
 }
 
 const RotateRenderer: React.FC<RotateRendererProps> = ({ object, radius, groupRef, isDragging }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const isClockwise = object.type === ObjectType.RotateCW;
 
     const style = getZoneStyle(object.color, Math.max(50, object.opacity), radius * 2, object.hollow);
@@ -113,7 +113,7 @@ const RotateRenderer: React.FC<RotateRendererProps> = ({ object, radius, groupRe
 
     return (
         <>
-            {showHighlight && <Circle radius={radius + style.strokeWidth / 2} {...SELECTED_PROPS} />}
+            {highlightProps && <Circle radius={radius + style.strokeWidth / 2} {...highlightProps} />}
 
             <HideGroup opacity={(object.opacity * 2) / 100} ref={groupRef}>
                 <Circle radius={radius} {...style} />

--- a/src/prefabs/zone/ZoneStack.tsx
+++ b/src/prefabs/zone/ZoneStack.tsx
@@ -10,13 +10,13 @@ import { registerRenderer, RendererProps } from '../../render/ObjectRegistry';
 import { ForegroundPortal } from '../../render/Portals';
 import { LayerName } from '../../render/layers';
 import { ObjectType, StackZone } from '../../scene';
-import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars, SELECTED_PROPS } from '../../theme';
+import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { useKonvaCache } from '../../useKonvaCache';
 import { usePanelDrag } from '../../usePanelDrag';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
 import { RadiusObjectContainer } from '../RadiusObjectContainer';
-import { useShowHighlight } from '../highlight';
+import { useHighlightProps } from '../highlight';
 import { useDraggableCenter } from '../useDraggableCenter';
 import { Orb } from './Orb';
 import { ChevronTail } from './shapes';
@@ -69,7 +69,7 @@ interface StackRendererProps extends RendererProps<StackZone> {
 }
 
 const StackRenderer: React.FC<StackRendererProps> = ({ object, radius }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const ring = getZoneStyle(object.color, object.opacity, radius * 2);
     const arrow = getArrowStyle(object.color, object.opacity * 2);
 
@@ -80,7 +80,7 @@ const StackRenderer: React.FC<StackRendererProps> = ({ object, radius }) => {
 
     return (
         <>
-            {showHighlight && <Circle radius={radius + ring.strokeWidth} {...SELECTED_PROPS} opacity={0.35} />}
+            {highlightProps && <Circle radius={radius + ring.strokeWidth} {...highlightProps} opacity={0.35} />}
 
             <HideGroup>
                 <Circle radius={radius} {...ring} opacity={0.75} fill="transparent" />

--- a/src/prefabs/zone/ZoneStarburst.tsx
+++ b/src/prefabs/zone/ZoneStarburst.tsx
@@ -1,3 +1,4 @@
+import { ShapeConfig } from 'konva/lib/Shape';
 import { CircleConfig } from 'konva/lib/shapes/Circle';
 import React from 'react';
 import { Circle, Group, Rect } from 'react-konva';
@@ -8,12 +9,12 @@ import { ListComponentProps, registerListComponent } from '../../panel/ListCompo
 import { registerRenderer, RendererProps } from '../../render/ObjectRegistry';
 import { LayerName } from '../../render/layers';
 import { ObjectType, StarburstZone } from '../../scene';
-import { CENTER_DOT_RADIUS, DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars, SELECTED_PROPS } from '../../theme';
+import { CENTER_DOT_RADIUS, DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { usePanelDrag } from '../../usePanelDrag';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
 import { MIN_STARBURST_SPOKE_WIDTH } from '../bounds';
-import { useShowHighlight } from '../highlight';
+import { useHighlightProps } from '../highlight';
 import { StarburstControlContainer } from './StarburstContainer';
 import { getZoneStyle } from './style';
 
@@ -63,14 +64,21 @@ interface StarburstConfig extends CircleConfig {
     radius: number;
     spokes: number;
     spokeWidth: number;
-    showHighlight: boolean;
+    highlightProps?: ShapeConfig;
 }
 
 function getOddRotations(spokes: number) {
     return Array.from({ length: spokes }).map((_, i) => 180 + (i / spokes) * 360);
 }
 
-const StarburstOdd: React.FC<StarburstConfig> = ({ rotation, radius, spokes, spokeWidth, showHighlight, ...props }) => {
+const StarburstOdd: React.FC<StarburstConfig> = ({
+    rotation,
+    radius,
+    spokes,
+    spokeWidth,
+    highlightProps,
+    ...props
+}) => {
     const items = getOddRotations(spokes);
 
     const rect = {
@@ -86,7 +94,7 @@ const StarburstOdd: React.FC<StarburstConfig> = ({ rotation, radius, spokes, spo
 
     return (
         <Group rotation={rotation}>
-            {showHighlight &&
+            {highlightProps &&
                 items.map((r, i) => (
                     <Rect
                         key={i}
@@ -94,7 +102,7 @@ const StarburstOdd: React.FC<StarburstConfig> = ({ rotation, radius, spokes, spo
                         offsetX={highlightWidth / 2}
                         width={highlightWidth}
                         height={highlightHeight}
-                        {...SELECTED_PROPS}
+                        {...highlightProps}
                     />
                 ))}
 
@@ -117,7 +125,7 @@ const StarburstEven: React.FC<StarburstConfig> = ({
     radius,
     spokes,
     spokeWidth,
-    showHighlight,
+    highlightProps,
     ...props
 }) => {
     const items = getEvenRotations(spokes);
@@ -136,7 +144,7 @@ const StarburstEven: React.FC<StarburstConfig> = ({
 
     return (
         <Group rotation={rotation}>
-            {showHighlight &&
+            {highlightProps &&
                 items.map((r, i) => (
                     <Rect
                         key={i}
@@ -145,7 +153,7 @@ const StarburstEven: React.FC<StarburstConfig> = ({
                         offsetY={highlightHeight / 2}
                         width={highlightWidth}
                         height={highlightHeight}
-                        {...SELECTED_PROPS}
+                        {...highlightProps}
                     />
                 ))}
 
@@ -166,7 +174,7 @@ interface StarburstRendererProps extends RendererProps<StarburstZone> {
 }
 
 const StarburstRenderer: React.FC<StarburstRendererProps> = ({ object, radius, rotation, spokeWidth, isDragging }) => {
-    const showSelected = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const style = getZoneStyle(object.color, object.opacity, object.spokeWidth * 2);
 
     const config: StarburstConfig = {
@@ -175,7 +183,7 @@ const StarburstRenderer: React.FC<StarburstRendererProps> = ({ object, radius, r
         rotation,
         spokeWidth,
         spokes: object.spokes,
-        showHighlight: showSelected,
+        highlightProps,
     };
 
     return (

--- a/src/prefabs/zone/ZoneTower.tsx
+++ b/src/prefabs/zone/ZoneTower.tsx
@@ -8,12 +8,12 @@ import { ListComponentProps, registerListComponent } from '../../panel/ListCompo
 import { registerRenderer, RendererProps } from '../../render/ObjectRegistry';
 import { LayerName } from '../../render/layers';
 import { ObjectType, TowerZone } from '../../scene';
-import { CENTER_DOT_RADIUS, DEFAULT_AOE_OPACITY, panelVars, SELECTED_PROPS } from '../../theme';
+import { CENTER_DOT_RADIUS, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { usePanelDrag } from '../../usePanelDrag';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
 import { RadiusObjectContainer } from '../RadiusObjectContainer';
-import { useShowHighlight } from '../highlight';
+import { useHighlightProps } from '../highlight';
 import { getStackCircleProps, STACK_CIRCLE_INSET } from './stackUtil';
 import { getZoneStyle } from './style';
 
@@ -75,14 +75,14 @@ interface TowerRendererProps extends RendererProps<TowerZone> {
 }
 
 const TowerRenderer: React.FC<TowerRendererProps> = ({ object, radius, isDragging }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const style = getZoneStyle(object.color, object.opacity, radius * 2);
 
     const towers = getStackCircleProps(radius, object.count, STACK_CIRCLE_INSET);
 
     return (
         <>
-            {showHighlight && <Circle radius={radius + style.strokeWidth / 2} {...SELECTED_PROPS} />}
+            {highlightProps && <Circle radius={radius + style.strokeWidth / 2} {...highlightProps} />}
 
             <HideGroup>
                 <Circle radius={radius} {...style} opacity={0.75} />

--- a/src/prefabs/zone/ZoneTriangle.tsx
+++ b/src/prefabs/zone/ZoneTriangle.tsx
@@ -8,12 +8,12 @@ import { ListComponentProps, registerListComponent } from '../../panel/ListCompo
 import { registerRenderer, RendererProps } from '../../render/ObjectRegistry';
 import { LayerName } from '../../render/layers';
 import { ObjectType, RectangleZone } from '../../scene';
-import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars, SELECTED_PROPS } from '../../theme';
+import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { usePanelDrag } from '../../usePanelDrag';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
 import { ResizeableObjectContainer } from '../ResizeableObjectContainer';
-import { useShowHighlight } from '../highlight';
+import { useHighlightProps } from '../highlight';
 import { getZoneStyle } from './style';
 
 const NAME = 'Triangle';
@@ -72,7 +72,7 @@ const EquilateralTriangle: React.FC<RectConfig> = ({ width, height, ...props }) 
 };
 
 const TriangleRenderer: React.FC<RendererProps<RectangleZone>> = ({ object }) => {
-    const showHighlight = useShowHighlight(object);
+    const highlightProps = useHighlightProps(object);
     const style = getZoneStyle(object.color, object.opacity, Math.min(object.width, object.height), object.hollow);
 
     const highlightOffset = style.strokeWidth;
@@ -85,13 +85,13 @@ const TriangleRenderer: React.FC<RendererProps<RectangleZone>> = ({ object }) =>
         <ResizeableObjectContainer object={object} transformerProps={{ centeredScaling: true }}>
             {(groupProps) => (
                 <Group {...groupProps} offsetY={offsetY}>
-                    {showHighlight && (
+                    {highlightProps && (
                         <EquilateralTriangle
                             offsetX={highlightOffset / 2}
                             offsetY={highlightOffset / 2}
                             width={highlightWidth}
                             height={highlightHeight}
-                            {...SELECTED_PROPS}
+                            {...highlightProps}
                         />
                     )}
                     <HideGroup>

--- a/src/render/SceneRenderer.tsx
+++ b/src/render/SceneRenderer.tsx
@@ -6,7 +6,7 @@ import { DefaultCursorProvider } from '../DefaultCursorProvider';
 import { getDropAction } from '../DropHandler';
 import { SceneHotkeyHandler } from '../HotkeyHandler';
 import { EditorState, SceneAction, SceneContext, useCurrentStep, useScene } from '../SceneProvider';
-import { SelectionContext, SelectionState } from '../SelectionContext';
+import { SelectionContext, SelectionState, SpotlightContext } from '../SelectionContext';
 import { getCanvasSize, getSceneCoord } from '../coord';
 import { Scene } from '../scene';
 import { selectNewObjects, selectNone, useSelection } from '../selection';
@@ -104,13 +104,16 @@ export const ScenePreview: React.FC<ScenePreviewProps> = ({
     ];
 
     const selectionContext: SelectionState = [new Set<number>(), () => {}];
+    const spotlightContext: SelectionState = [new Set<number>(), () => {}];
 
     return (
         <Stage ref={ref} x={x} y={y} width={width} height={height} scaleX={scale} scaleY={scale}>
             <DefaultCursorProvider>
                 <SceneContext value={sceneContext}>
                     <SelectionContext value={selectionContext}>
-                        <SceneContents listening={false} simple={simple} backgroundColor={backgroundColor} />
+                        <SpotlightContext value={spotlightContext}>
+                            <SceneContents listening={false} simple={simple} backgroundColor={backgroundColor} />
+                        </SpotlightContext>
                     </SelectionContext>
                 </SceneContext>
             </DefaultCursorProvider>

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1,30 +1,17 @@
 import { useContext } from 'react';
-import { useCurrentStep } from './SceneProvider';
-import { SceneSelection, SelectionContext, SelectionState } from './SelectionContext';
+import { SceneSelection, SelectionContext, SelectionState, SpotlightContext } from './SelectionContext';
 import { Scene, SceneObject, SceneStep } from './scene';
 
 export function useSelection(): SelectionState {
     return useContext(SelectionContext);
 }
 
-export interface SelectedObjects {
-    objects: readonly SceneObject[];
+export function useSpotlight(): SelectionState {
+    return useContext(SpotlightContext);
 }
 
 export function getSelectedObjects(step: SceneStep, selection: SceneSelection): readonly SceneObject[] {
     return step.objects.filter((object) => selection.has(object.id));
-}
-
-export function useSelectedObjects(): readonly SceneObject[] {
-    const step = useCurrentStep();
-    const [selection] = useSelection();
-
-    return getSelectedObjects(step, selection);
-}
-
-export function useIsSelected(object: SceneObject): boolean {
-    const [selection] = useSelection();
-    return selection.has(object.id);
 }
 
 export function selectSingle(id: number): SceneSelection {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -42,6 +42,7 @@ export const DEFAULT_ENEMY_COLOR = COLOR_RED;
 export const DEFAULT_ENEMY_OPACITY = 65;
 
 export const HIGHLIGHT_COLOR = '#fff';
+export const SPOTLIGHT_COLOR = '#f00';
 export const HIGHLIGHT_WIDTH = 1.5;
 
 export const SELECTED_PROPS: ShapeConfig = {
@@ -50,6 +51,16 @@ export const SELECTED_PROPS: ShapeConfig = {
     stroke: HIGHLIGHT_COLOR,
     strokeWidth: HIGHLIGHT_WIDTH,
     shadowColor: '#06f',
+    shadowBlur: 4,
+    opacity: 0.75,
+};
+
+export const SPOTLIGHT_PROPS: ShapeConfig = {
+    fillEnabled: false,
+    listening: false,
+    stroke: SPOTLIGHT_COLOR,
+    strokeWidth: HIGHLIGHT_WIDTH,
+    shadowColor: '#ff0',
     shadowBlur: 4,
     opacity: 0.75,
 };


### PR DESCRIPTION
The regular selection styling (including 'resizer') still takes precedent if the object to spotlight is the only selected object, but this will override the regular selection highlight if multiple objects are selected (e.g. to help with finding one thing to exclude after Ctrl+A).

The setup is parallel to the Selection setup, to avoid having to refactor the selection setup itself (and having to come up with names that read better than yielding `selection.selection`).
It also uses a Set to hold the object id to highlight, even though there will be at most one entry. I started with making the `onMouseEnter` and `onMouseLeave` events add/remove the item instead of setting the value directly, but quickly found that some of the `onMouseLeave` events are omitted when jiggling the mouse cursor. I kept the Set afterwards so I didn't have to create a new structure just to not have to use a placeholder value for "nothing needs the spotlight".

Along the way, make Tethers use the same setup as everything else, instead of manually checking the selection set.

I picked the spotlight highlight colors in a way that they looked distinguishable from both 'unselected' and 'selected' states for most objects, but there are probably better color combinations available. (maybe it also needs a `dash: [10,5]`?)