### PR TITLE
Add a tool to make common icon swaps automatically

### DIFF
--- a/src/SceneProvider.tsx
+++ b/src/SceneProvider.tsx
@@ -94,6 +94,11 @@ export interface ObjectUpdateAction {
     value: SceneObject | readonly SceneObject[];
 }
 
+export interface ObjectUpdateAllStepsAction {
+    type: 'updateAllSteps';
+    value: SceneObject | readonly SceneObject[];
+}
+
 /**
  * Action which adds properties to and/or removes them from objects with the given IDs.
  *
@@ -141,6 +146,7 @@ export type ObjectAction =
     | ObjectMoveAction
     | GroupMoveAction
     | ObjectUpdateAction
+    | ObjectUpdateAllStepsAction
     | ObjectUpdatePropsAction;
 
 export interface SetStepAction {
@@ -641,6 +647,20 @@ function updateObjects(state: Readonly<EditorState>, values: readonly SceneObjec
     return updateCurrentStep(state, { objects });
 }
 
+function updateObjectsAllSteps(state: Readonly<EditorState>, values: readonly SceneObject[]): EditorState {
+    const steps = state.scene.steps.map((step) => {
+        const objects = step.objects.slice();
+        for (const update of values) {
+            const index = objects.findIndex((o) => o.id === update.id);
+            if (index >= 0) {
+                objects[index] = update;
+            }
+        }
+        return { ...step, objects };
+    });
+    return { ...state, scene: { ...state.scene, steps } };
+}
+
 function updateObjectProps(
     state: Readonly<EditorState>,
     ids: readonly number[],
@@ -750,6 +770,9 @@ function sceneReducer(state: Readonly<EditorState>, action: SceneAction): Editor
 
         case 'update':
             return updateObjects(state, asArray(action.value));
+
+        case 'updateAllSteps':
+            return updateObjectsAllSteps(state, asArray(action.value));
 
         case 'updateProps':
             return updateObjectProps(state, action.ids, action.props, action.omit);

--- a/src/panel/DetailsPanel.tsx
+++ b/src/panel/DetailsPanel.tsx
@@ -6,9 +6,11 @@ import { useControlStyles } from '../useControlStyles';
 import { PANEL_PADDING, PANEL_WIDTH, WIDE_PANEL_WIDTH } from './PanelStyles';
 import { PropertiesPanel } from './PropertiesPanel';
 import { SceneObjectsPanel } from './SceneObjectsPanel';
+import { ToolsPanel } from './ToolsPanel';
 
 const PROPERTIES_TITLE = 'Properties';
 const OBJECTS_TITLE = 'Scene';
+const TOOLS_TITLE = 'Tools';
 
 export const DetailsPanel: React.FC = () => {
     const isWide = useMedia(`(min-width: 1700px)`);
@@ -41,6 +43,15 @@ const WideDetailsPanel: React.FC = () => {
                     <SceneObjectsPanel />
                 </div>
             </section>
+
+            <Divider inset vertical className={controlClasses.divider} />
+
+            <section className={mergeClasses(classes.section, classes.wideSection)}>
+                <header className={classes.header}>{TOOLS_TITLE}</header>
+                <div className={classes.scrollable}>
+                    <ToolsPanel />
+                </div>
+            </section>
         </div>
     );
 };
@@ -56,12 +67,16 @@ const ShortDetailsPanel: React.FC = () => {
             <TabList selectedValue={tab} onTabSelect={(ev, data) => setTab(data.value as Tabs)}>
                 <Tab value="properties">{PROPERTIES_TITLE}</Tab>
                 <Tab value="objects">{OBJECTS_TITLE}</Tab>
+                <Tab value="tools">{TOOLS_TITLE}</Tab>
             </TabList>
             <TabActivity value="properties" activeTab={tab}>
                 <PropertiesPanel className={classes.shortPanelContent} />
             </TabActivity>
             <TabActivity value="objects" activeTab={tab}>
                 <SceneObjectsPanel className={classes.shortPanelContent} />
+            </TabActivity>
+            <TabActivity value="tools" activeTab={tab}>
+                <ToolsPanel className={classes.shortPanelContent} />
             </TabActivity>
         </div>
     );

--- a/src/panel/SwapIconsControl.tsx
+++ b/src/panel/SwapIconsControl.tsx
@@ -1,7 +1,7 @@
-import { Button, Image, makeStyles, tokens } from '@fluentui/react-components';
-import React from 'react';
+import { Button, Image, makeStyles, Switch, tokens } from '@fluentui/react-components';
+import React, { createContext, use, useState } from 'react';
 import { getJob, getJobIconUrl, Job } from '../jobs';
-import { isImageObject, type SceneObject, type SceneStep } from '../scene';
+import { isImageObject, type Scene, type SceneObject, type SceneStep } from '../scene';
 import type { EditorState } from '../SceneProvider';
 import { type SceneAction, useScene } from '../SceneProvider';
 import type { UndoRedoAction } from '../undo/undoReducer';
@@ -81,11 +81,7 @@ function jobIcon(job: Job) {
     return <Image key={job} src={getJobIconUrl(icon)} title={name} width={24} height={24} draggable={false} />;
 }
 
-function swapIcons(
-    dispatch: React.Dispatch<SceneAction | UndoRedoAction<EditorState>>,
-    step: SceneStep,
-    swaps: IconSwaps,
-) {
+function collectSwaps(step: SceneStep, swaps: IconSwaps): SceneObject[] {
     const updates: SceneObject[] = [];
     for (const object of step.objects) {
         if (isImageObject(object)) {
@@ -95,11 +91,24 @@ function swapIcons(
             }
         }
     }
+    return updates;
+}
 
+function swapIcons(
+    dispatch: React.Dispatch<SceneAction | UndoRedoAction<EditorState>>,
+    scene: Scene,
+    step: SceneStep,
+    swaps: IconSwaps,
+    allSteps: boolean,
+) {
+    const steps = allSteps ? scene.steps : [step];
+    const updates = steps.flatMap((s) => collectSwaps(s, swaps));
     if (updates.length > 0) {
-        dispatch({ type: 'update', value: updates });
+        dispatch({ type: allSteps ? 'updateAllSteps' : 'update', value: updates });
     }
 }
+
+const AllStepsToggleContext = createContext(false);
 
 interface SwapButtonProps {
     swaps: IconSwaps;
@@ -108,11 +117,12 @@ interface SwapButtonProps {
 }
 
 const SwapButton: React.FC<SwapButtonProps> = ({ swaps, left, right }) => {
-    const { dispatch, step } = useScene();
+    const { dispatch, step, scene } = useScene();
+    const allSteps = use(AllStepsToggleContext);
     const classes = useStyles();
 
     return (
-        <Button className={classes.button} onClick={() => swapIcons(dispatch, step, swaps)}>
+        <Button className={classes.button} onClick={() => swapIcons(dispatch, scene, step, swaps, allSteps)}>
             <span className={classes.icons}>
                 {left.map(jobIcon)}
                 {'⇔'}
@@ -123,36 +133,45 @@ const SwapButton: React.FC<SwapButtonProps> = ({ swaps, left, right }) => {
 };
 
 export const SwapIconsControl: React.FC = () => {
+    const [allSteps, setAllSteps] = useState(false);
     const classes = useStyles();
+
     return (
-        <div className={classes.container}>
-            <SwapButton
-                swaps={SWAP_DPS_1234_WITH_MR_12}
-                left={[Job.RoleMelee1, Job.RoleRanged1]}
-                right={[Job.RoleDps1, Job.RoleDps3]}
-            />
-            <SwapButton
-                swaps={SWAP_H12_WITH_PURE_BARRIER}
-                left={[Job.RoleHealer1, Job.RoleHealer2]}
-                right={[Job.RolePureHealer, Job.RoleBarrierHealer]}
-            />
-            <SwapButton
-                swaps={SWAP_R12_WITH_PHYSICAL_MAGIC}
-                left={[Job.RoleRanged1, Job.RoleRanged2]}
-                right={[Job.RolePhysicalRanged, Job.RoleMagicRanged]}
-            />
-            <SwapButton
-                swaps={SWAP_M12_WITH_R12}
-                left={[Job.RoleMelee1, Job.RoleMelee2]}
-                right={[Job.RoleRanged1, Job.RoleRanged2]}
-            />
-            <SwapButton swaps={SWAP_TANKS} left={[Job.RoleTank1]} right={[Job.RoleTank2]} />
-            <SwapButton
-                swaps={SWAP_LIGHT_PARTIES}
-                left={[Job.RoleTank1, Job.RoleHealer1, Job.RoleDps1]}
-                right={[Job.RoleTank2, Job.RoleHealer2, Job.RoleDps2]}
-            />
-        </div>
+        <AllStepsToggleContext value={allSteps}>
+            <div className={classes.container}>
+                <SwapButton
+                    swaps={SWAP_DPS_1234_WITH_MR_12}
+                    left={[Job.RoleMelee1, Job.RoleRanged1]}
+                    right={[Job.RoleDps1, Job.RoleDps3]}
+                />
+                <SwapButton
+                    swaps={SWAP_H12_WITH_PURE_BARRIER}
+                    left={[Job.RoleHealer1, Job.RoleHealer2]}
+                    right={[Job.RolePureHealer, Job.RoleBarrierHealer]}
+                />
+                <SwapButton
+                    swaps={SWAP_R12_WITH_PHYSICAL_MAGIC}
+                    left={[Job.RoleRanged1, Job.RoleRanged2]}
+                    right={[Job.RolePhysicalRanged, Job.RoleMagicRanged]}
+                />
+                <SwapButton
+                    swaps={SWAP_M12_WITH_R12}
+                    left={[Job.RoleMelee1, Job.RoleMelee2]}
+                    right={[Job.RoleRanged1, Job.RoleRanged2]}
+                />
+                <SwapButton swaps={SWAP_TANKS} left={[Job.RoleTank1]} right={[Job.RoleTank2]} />
+                <SwapButton
+                    swaps={SWAP_LIGHT_PARTIES}
+                    left={[Job.RoleTank1, Job.RoleHealer1, Job.RoleDps1]}
+                    right={[Job.RoleTank2, Job.RoleHealer2, Job.RoleDps2]}
+                />
+                <Switch
+                    label="Apply to all steps"
+                    checked={allSteps}
+                    onChange={(_, data) => setAllSteps(data.checked)}
+                />
+            </div>
+        </AllStepsToggleContext>
     );
 };
 
@@ -162,10 +181,10 @@ const useStyles = makeStyles({
         flexDirection: 'column',
         width: 'fit-content',
         alignSelf: 'center',
-        gap: tokens.spacingVerticalM,
+        gap: tokens.spacingVerticalS,
     },
     button: {
-        padding: '5px 12px 4px',
+        padding: '6px 8px 5px',
         minWidth: 0,
     },
     icons: {

--- a/src/panel/SwapIconsControl.tsx
+++ b/src/panel/SwapIconsControl.tsx
@@ -1,0 +1,177 @@
+import { Button, Image, makeStyles, tokens } from '@fluentui/react-components';
+import React from 'react';
+import { getJob, getJobIconUrl, Job } from '../jobs';
+import { isImageObject, type SceneObject, type SceneStep } from '../scene';
+import type { EditorState } from '../SceneProvider';
+import { type SceneAction, useScene } from '../SceneProvider';
+import type { UndoRedoAction } from '../undo/undoReducer';
+
+type IconSwaps = Map<string, { name: string; image: string }>;
+
+function makeIconSwaps(swaps: Partial<Record<Job, Job>>): IconSwaps {
+    return new Map(
+        (Object.entries(swaps) as [string, Job][]).map(([from, to]) => {
+            const toProps = getJob(to);
+            return [
+                getJobIconUrl(getJob(Number(from) as Job).icon),
+                { name: toProps.name, image: getJobIconUrl(toProps.icon) },
+            ];
+        }),
+    );
+}
+
+const SWAP_DPS_1234_WITH_MR_12 = makeIconSwaps({
+    [Job.RoleDps1]: Job.RoleMelee1,
+    [Job.RoleDps2]: Job.RoleMelee2,
+    [Job.RoleDps3]: Job.RoleRanged1,
+    [Job.RoleDps4]: Job.RoleRanged2,
+    [Job.RoleMelee1]: Job.RoleDps1,
+    [Job.RoleMelee2]: Job.RoleDps2,
+    [Job.RoleRanged1]: Job.RoleDps3,
+    [Job.RoleRanged2]: Job.RoleDps4,
+});
+
+const SWAP_H12_WITH_PURE_BARRIER = makeIconSwaps({
+    [Job.RoleHealer1]: Job.RolePureHealer,
+    [Job.RoleHealer2]: Job.RoleBarrierHealer,
+    [Job.RolePureHealer]: Job.RoleHealer1,
+    [Job.RoleBarrierHealer]: Job.RoleHealer2,
+});
+
+const SWAP_R12_WITH_PHYSICAL_MAGIC = makeIconSwaps({
+    [Job.RoleRanged1]: Job.RolePhysicalRanged,
+    [Job.RoleRanged2]: Job.RoleMagicRanged,
+    [Job.RolePhysicalRanged]: Job.RoleRanged1,
+    [Job.RoleMagicRanged]: Job.RoleRanged2,
+});
+
+const SWAP_M12_WITH_R12 = makeIconSwaps({
+    [Job.RoleRanged1]: Job.RoleMelee1,
+    [Job.RoleRanged2]: Job.RoleMelee2,
+    [Job.RoleMelee1]: Job.RoleRanged1,
+    [Job.RoleMelee2]: Job.RoleRanged2,
+});
+
+const SWAP_TANKS = makeIconSwaps({
+    [Job.RoleTank1]: Job.RoleTank2,
+    [Job.RoleTank2]: Job.RoleTank1,
+});
+
+const SWAP_LIGHT_PARTIES = makeIconSwaps({
+    [Job.RoleTank1]: Job.RoleTank2,
+    [Job.RoleTank2]: Job.RoleTank1,
+    [Job.RoleHealer1]: Job.RoleHealer2,
+    [Job.RoleHealer2]: Job.RoleHealer1,
+    [Job.RoleMelee1]: Job.RoleMelee2,
+    [Job.RoleMelee2]: Job.RoleMelee1,
+    [Job.RoleRanged1]: Job.RoleRanged2,
+    [Job.RoleRanged2]: Job.RoleRanged1,
+    [Job.RoleDps1]: Job.RoleDps2,
+    [Job.RoleDps2]: Job.RoleDps1,
+    [Job.RoleDps3]: Job.RoleDps4,
+    [Job.RoleDps4]: Job.RoleDps3,
+    [Job.RolePureHealer]: Job.RoleBarrierHealer,
+    [Job.RoleBarrierHealer]: Job.RolePureHealer,
+    [Job.RolePhysicalRanged]: Job.RoleMagicRanged,
+    [Job.RoleMagicRanged]: Job.RolePhysicalRanged,
+});
+
+function jobIcon(job: Job) {
+    const { icon, name } = getJob(job);
+    return <Image key={job} src={getJobIconUrl(icon)} title={name} width={24} height={24} draggable={false} />;
+}
+
+function swapIcons(
+    dispatch: React.Dispatch<SceneAction | UndoRedoAction<EditorState>>,
+    step: SceneStep,
+    swaps: IconSwaps,
+) {
+    const updates: SceneObject[] = [];
+    for (const object of step.objects) {
+        if (isImageObject(object)) {
+            const newProps = swaps.get(object.image);
+            if (newProps !== undefined) {
+                updates.push({ ...object, ...newProps } as SceneObject);
+            }
+        }
+    }
+
+    if (updates.length > 0) {
+        dispatch({ type: 'update', value: updates });
+    }
+}
+
+interface SwapButtonProps {
+    swaps: IconSwaps;
+    left: Job[];
+    right: Job[];
+}
+
+const SwapButton: React.FC<SwapButtonProps> = ({ swaps, left, right }) => {
+    const { dispatch, step } = useScene();
+    const classes = useStyles();
+
+    return (
+        <Button className={classes.button} onClick={() => swapIcons(dispatch, step, swaps)}>
+            <span className={classes.icons}>
+                {left.map(jobIcon)}
+                {'⇔'}
+                {right.map(jobIcon)}
+            </span>
+        </Button>
+    );
+};
+
+export const SwapIconsControl: React.FC = () => {
+    const classes = useStyles();
+    return (
+        <div className={classes.container}>
+            <SwapButton
+                swaps={SWAP_DPS_1234_WITH_MR_12}
+                left={[Job.RoleMelee1, Job.RoleRanged1]}
+                right={[Job.RoleDps1, Job.RoleDps3]}
+            />
+            <SwapButton
+                swaps={SWAP_H12_WITH_PURE_BARRIER}
+                left={[Job.RoleHealer1, Job.RoleHealer2]}
+                right={[Job.RolePureHealer, Job.RoleBarrierHealer]}
+            />
+            <SwapButton
+                swaps={SWAP_R12_WITH_PHYSICAL_MAGIC}
+                left={[Job.RoleRanged1, Job.RoleRanged2]}
+                right={[Job.RolePhysicalRanged, Job.RoleMagicRanged]}
+            />
+            <SwapButton
+                swaps={SWAP_M12_WITH_R12}
+                left={[Job.RoleMelee1, Job.RoleMelee2]}
+                right={[Job.RoleRanged1, Job.RoleRanged2]}
+            />
+            <SwapButton swaps={SWAP_TANKS} left={[Job.RoleTank1]} right={[Job.RoleTank2]} />
+            <SwapButton
+                swaps={SWAP_LIGHT_PARTIES}
+                left={[Job.RoleTank1, Job.RoleHealer1, Job.RoleDps1]}
+                right={[Job.RoleTank2, Job.RoleHealer2, Job.RoleDps2]}
+            />
+        </div>
+    );
+};
+
+const useStyles = makeStyles({
+    container: {
+        display: 'flex',
+        flexDirection: 'column',
+        width: 'fit-content',
+        alignSelf: 'center',
+        gap: tokens.spacingVerticalM,
+    },
+    button: {
+        padding: '5px 12px 4px',
+        minWidth: 0,
+    },
+    icons: {
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: tokens.spacingHorizontalXS,
+    },
+});

--- a/src/panel/ToolsPanel.tsx
+++ b/src/panel/ToolsPanel.tsx
@@ -1,0 +1,21 @@
+import { mergeClasses } from '@fluentui/react-components';
+import React from 'react';
+import { useControlStyles } from '../useControlStyles';
+import { Section } from './Section';
+import { SwapIconsControl } from './SwapIconsControl';
+
+export interface ToolsPanelProps {
+    className?: string;
+}
+
+export const ToolsPanel: React.FC<ToolsPanelProps> = ({ className }) => {
+    const classes = useControlStyles();
+
+    return (
+        <div className={mergeClasses(classes.panel, classes.noSelect, className)}>
+            <Section title="Swap Icons">
+                <SwapIconsControl />
+            </Section>
+        </div>
+    );
+};


### PR DESCRIPTION
This adds a new "Tools" tab on the right pane with buttons to swap common icon substitutions, optionally across all scenes. This is intended to make it easy to convert, for instance, between NA (which use melee/ranged 1/2 markers) and rest-of-world conventions (which use dps 1/2/3/4), as well as swapping generic to more specific role icons, swapping the ranged and melees for wall situations, and swapping the tanks if that ends up being necessary.