### PR TITLE
Improve arrow handling and rendering

### DIFF
--- a/src/arrowUtil.ts
+++ b/src/arrowUtil.ts
@@ -23,7 +23,7 @@ export function getArrowStrokeExtent(length: number, width: number, strokeWidth:
     }
 
     //           +
-    //          /| A
+    //          /| C
     //         / +
     //        / /|
     //       / / |
@@ -42,22 +42,21 @@ export function getArrowStrokeExtent(length: number, width: number, strokeWidth:
     // theta = atan(L / W)
     //
     // Then
-    // A = S / sin(theta)
-    // B = S / tan(theta)
+    // cos(theta) = S / C
+    // L / W = (C + L + S) / (A + B + W)
     //
-    // Top extension = A = S / sin(theta)
+    // Top extension = C = S / cos(theta)
     // Bottom extension = S
-    // Side extension = A + B = S * (1 / sin(theta) + 1 / tan(theta))
+    // Side extension = A + B = ((C + L + S) / (L/W)) - W
 
-    const halfStroke = strokeWidth / 2;
-    const tangent = length / (width / 2);
-    const cotangent = 1 / tangent;
-    const cosecant = 1 / Math.sin(Math.atan(tangent));
-
+    const halfStroke = strokeWidth / 2; // S
+    const halfWidth = width / 2; // W
+    const tangent = length / halfWidth;
+    const topExtent = halfStroke / Math.cos(Math.atan(tangent)); // C
     return {
-        top: halfStroke * cosecant,
+        top: topExtent,
         bottom: halfStroke,
-        side: halfStroke * (cotangent + cosecant),
+        side: (topExtent + length + halfStroke) / tangent - halfWidth, // A + B
     };
 }
 

--- a/src/arrowUtil.ts
+++ b/src/arrowUtil.ts
@@ -1,3 +1,5 @@
+import { degtorad } from './util';
+
 export interface ArrowStrokeExtent {
     /** Amount the stroke will extend past the top of the arrow head */
     top: number;
@@ -57,4 +59,54 @@ export function getArrowStrokeExtent(length: number, width: number, strokeWidth:
         bottom: halfStroke,
         side: halfStroke * (cotangent + cosecant),
     };
+}
+
+export interface ArrowPointerDimensions {
+    pointerWidth: number;
+    pointerLength: number;
+}
+
+/**
+ * Calculate the pointer width and length to get an arrow matching the given dimensions.
+ * @param width the total width of the base of the pointer
+ * @param baseAngle the desired angle at the base of the pointer, in degrees
+ * @param strokeWidth the stroke width used to draw the arrow
+ */
+export function getArrowPointerDimensions(
+    width: number,
+    baseAngle: number,
+    strokeWidth: number,
+): ArrowPointerDimensions {
+    //           +
+    //          /| C
+    //         / O
+    //        / /|
+    //       / / |
+    //      / /  | L
+    //     / /   |
+    //    / /    |
+    //   +-+-----+
+    //  / /|     | S
+    // +-+-+-----+
+    //  A B   W
+    //
+    // Given
+    // width = (A+B+W) * 2
+    // strokeWidth = S * 2
+    // tan(baseAngle) = (C+L+S) / (A+B+W)
+    //
+    // Then
+    // cos(baseAngle) = S / C
+    // tan(baseAngle) = L / W
+
+    const theta = degtorad(baseAngle);
+
+    const halfStroke = strokeWidth / 2; // S
+    const tangent = Math.tan(theta);
+    const totalLength = tangent * (width / 2); // C + L + S
+    const topExtent = halfStroke / Math.cos(theta); // C
+    const pointerLength = totalLength - topExtent - halfStroke; // L
+    const halfWidth = pointerLength / tangent; // W
+
+    return { pointerLength, pointerWidth: halfWidth * 2 };
 }

--- a/src/connections.ts
+++ b/src/connections.ts
@@ -265,6 +265,7 @@ export type AttachmentSettings = {
 export function getDefaultAttachmentSettings(object: UnknownObject): AttachmentSettings {
     switch (object.type) {
         case ObjectType.Arc:
+        case ObjectType.Arrow:
         case ObjectType.Cone:
         case ObjectType.Donut:
         case ObjectType.Line:

--- a/src/file/upgrade.ts
+++ b/src/file/upgrade.ts
@@ -1,20 +1,25 @@
 import type { Vector2d } from 'konva/lib/types';
+import { getAbsoluteRotation, getBaseFacingRotation, rotateCoord } from '../coord';
 import {
+    type ArrowObject,
     type DrawObject,
     type EnemyObject,
     EnemyRingStyle,
     type ExaflareZone,
     type ImageObject,
     type MarkerObject,
+    type MoveableObject,
     type PartyObject,
     type PolygonOrientation,
     type PolygonZone,
+    type RotateableObject,
     type Scene,
     type SceneObject,
     type SceneStep,
     type StackZone,
     type TextObject,
     type TextStyle,
+    isArrow,
     isDrawObject,
     isEnemy,
     isExaflareZone,
@@ -26,22 +31,23 @@ import {
     isText,
 } from '../scene';
 import { DEFAULT_ENEMY_OPACITY, DEFAULT_IMAGE_OPACITY, DEFAULT_MARKER_OPACITY, DEFAULT_PARTY_OPACITY } from '../theme';
+import { omit } from '../util';
 
 export function upgradeScene(scene: Scene): Scene {
     return {
         ...scene,
-        steps: scene.steps.map(upgradeStep),
+        steps: scene.steps.map((step) => upgradeStep(scene, step)),
     };
 }
 
-function upgradeStep(step: SceneStep): SceneStep {
+function upgradeStep(scene: Scene, step: SceneStep): SceneStep {
     return {
         ...step,
-        objects: step.objects.map(upgradeObject),
+        objects: step.objects.map((obj) => upgradeObject(scene, obj)),
     };
 }
 
-function upgradeObject(object: SceneObject): SceneObject {
+function upgradeObject(scene: Scene, object: SceneObject): SceneObject {
     if (isEnemy(object)) {
         object = upgradeEnemy(object);
     }
@@ -76,6 +82,10 @@ function upgradeObject(object: SceneObject): SceneObject {
 
     if (isStackZone(object)) {
         object = upgradeStackZone(object);
+    }
+
+    if (isArrow(object)) {
+        object = upgradeArrow(scene, object);
     }
 
     return object;
@@ -233,4 +243,47 @@ function upgradeStackZone(object: LegacyStackZone): StackZone {
         count: 1,
         ...object,
     };
+}
+
+// Arrow used to be a fancy ZoneRectangle, but is now a fancy ZoneLine
+type LegacyArrow = Omit<ArrowObject, 'length'> & {
+    height?: number;
+};
+
+function upgradeArrow(scene: Scene, object: LegacyArrow): ArrowObject {
+    if (object.height === undefined) {
+        return object as ArrowObject;
+    }
+    const absoluteRotation = getAbsoluteRotation(scene, object);
+    // The old arrow was scaled from the default-length arrow including "extent" measures that used
+    // the static stroke width, resulting in more deviation from the configured length the more it
+    // was different from the default length. However since we're changing how arrows render anyway,
+    // keeping the coordinates and length value intact is more likely to yield the desired (or
+    // most-expected) outcome for users.
+    // const length = object.height + ((object.height - DEFAULT_ARROW_LENGTH) / DEFAULT_ARROW_LENGTH) * ARROW_STROKE_WIDTH;
+    const length = object.height;
+    const offset = rotateCoord({ x: 0, y: -length / 2 }, absoluteRotation);
+
+    return {
+        // Omit the unused height to avoid doubled-up size property controls
+        ...omit(object, 'height'),
+
+        length,
+        x: object.x + offset.x,
+        y: object.y + offset.y,
+        rotation: updateRotation(scene, object, offset),
+    };
+}
+
+/**
+ * Calculate the new rotation an object should have to retain the same absolute rotation, after its origin
+ * has been moved by the given offset.
+ */
+function updateRotation(scene: Scene, object: MoveableObject & RotateableObject, offset: Vector2d): number {
+    if (object.facingId === undefined) {
+        return object.rotation;
+    }
+    const originalBaseRotation = getBaseFacingRotation(scene, object);
+    const newBaseRotation = getBaseFacingRotation(scene, { ...object, x: object.x + offset.x, y: object.y + offset.y });
+    return object.rotation + (originalBaseRotation - newBaseRotation);
 }

--- a/src/panel/PropertiesPanel.tsx
+++ b/src/panel/PropertiesPanel.tsx
@@ -6,6 +6,7 @@ import { EditMode } from '../editMode';
 import {
     type SceneObject,
     type UnknownObject,
+    hasLineProperties,
     isArcZone,
     isArrow,
     isColored,
@@ -17,7 +18,6 @@ import {
     isIcon,
     isImageObject,
     isInnerRadiusObject,
-    isLineZone,
     isMarker,
     isMoveable,
     isNamed,
@@ -172,7 +172,7 @@ const Controls: React.FC = () => {
             {/* Position/Size */}
             <ControlCondition objects={objects} test={isMoveable} control={PositionControl} />
             <ControlCondition objects={objects} test={isResizable} control={SizeControl} />
-            <ControlCondition objects={objects} test={isLineZone} control={LineSizeControl} />
+            <ControlCondition objects={objects} test={hasLineProperties} control={LineSizeControl} />
 
             {/* TODO: change this to a two-column grid? */}
             <div className={mergeClasses(classes.row, classes.rightGap)}>

--- a/src/panel/properties/LineControls.tsx
+++ b/src/panel/properties/LineControls.tsx
@@ -1,13 +1,13 @@
 import { Field, mergeClasses } from '@fluentui/react-components';
 import { MIN_LINE_LENGTH, MIN_LINE_WIDTH } from '../../prefabs/bounds';
-import type { LineZone } from '../../scene';
+import type { LineProps } from '../../scene';
 import { SpinButton } from '../../SpinButton';
 import { useControlStyles } from '../../useControlStyles';
 import { useObjectUpdater } from '../../useObjectUpdater';
 import { commonValue } from '../../util';
 import type { PropertiesControlProps } from '../PropertiesControl';
 
-export const LineSizeControl: React.FC<PropertiesControlProps<LineZone>> = ({ objects }) => {
+export const LineSizeControl: React.FC<PropertiesControlProps<LineProps>> = ({ objects }) => {
     const classes = useControlStyles();
     const update = useObjectUpdater(objects);
 

--- a/src/prefabs/Arrow.tsx
+++ b/src/prefabs/Arrow.tsx
@@ -1,7 +1,7 @@
 import { ArrowUpRegular } from '@fluentui/react-icons';
 import type { ArrowConfig } from 'konva/lib/shapes/Arrow';
 import { Arrow, Group, Rect } from 'react-konva';
-import { registerDropHandler } from '../DropHandler';
+import { getDragOffset, registerDropHandler } from '../DropHandler';
 import { getArrowPointerDimensions } from '../arrowUtil';
 import { DetailsItem } from '../panel/DetailsItem';
 import { type ListComponentProps, registerListComponent } from '../panel/ListComponentRegistry';
@@ -12,6 +12,7 @@ import { COLOR_RED } from '../theme';
 import { CompositeReplaceGroup } from './CompositeReplaceGroup';
 import { HideCutoutGroup } from './HideGroup';
 import { PrefabIcon } from './PrefabIcon';
+import { PREFAB_ICON_SIZE } from './PrefabIconStyles';
 import { useHighlightProps, useOverrideProps } from './highlight';
 import { createLineShapeContainer, type LineShapeRendererProps } from './lines';
 
@@ -38,6 +39,13 @@ export const MarkerArrow: React.FC = () => {
                 width: DEFAULT_ARROW_WIDTH,
                 length: DEFAULT_ARROW_LENGTH,
                 arrowEnd: true,
+            }}
+            getOffset={(e) => {
+                const offset = getDragOffset(e);
+                return {
+                    x: offset.x,
+                    y: offset.y - PREFAB_ICON_SIZE / 2,
+                };
             }}
         />
     );

--- a/src/prefabs/Arrow.tsx
+++ b/src/prefabs/Arrow.tsx
@@ -1,30 +1,30 @@
 import { ArrowUpRegular } from '@fluentui/react-icons';
 import type { ArrowConfig } from 'konva/lib/shapes/Arrow';
-import * as React from 'react';
 import { Arrow, Group, Rect } from 'react-konva';
 import { registerDropHandler } from '../DropHandler';
-import { getArrowStrokeExtent } from '../arrowUtil';
+import { getArrowPointerDimensions } from '../arrowUtil';
 import { DetailsItem } from '../panel/DetailsItem';
 import { type ListComponentProps, registerListComponent } from '../panel/ListComponentRegistry';
-import { type RendererProps, registerRenderer } from '../render/ObjectRegistry';
+import { registerRenderer } from '../render/ObjectRegistry';
 import { LayerName } from '../render/layers';
 import { type ArrowObject, ObjectType } from '../scene';
 import { COLOR_RED } from '../theme';
 import { CompositeReplaceGroup } from './CompositeReplaceGroup';
 import { HideCutoutGroup } from './HideGroup';
 import { PrefabIcon } from './PrefabIcon';
-import { ResizeableObjectContainer } from './ResizeableObjectContainer';
 import { useHighlightProps, useOverrideProps } from './highlight';
-
-// TODO: This would be a lot nicer if you could just click on start position
-// and drag to end position instead of having a set initial size/rotation.
+import { createLineShapeContainer, type LineShapeRendererProps } from './lines';
 
 const NAME = 'Arrow';
 
 const DEFAULT_ARROW_WIDTH = 30;
-const DEFAULT_ARROW_HEIGHT = 150;
+const MIN_ARROW_WIDTH = 20;
+const DEFAULT_ARROW_LENGTH = 150;
+const MIN_ARROW_LENGTH = 20;
 const DEFAULT_ARROW_COLOR = COLOR_RED;
 const DEFAULT_ARROW_OPACITY = 100;
+const ARROW_POINTER_BASE_ANGLE = 60;
+const ARROW_SHAFT_WIDTH_FRACTION = 0.2;
 
 const Icon = ArrowUpRegular;
 
@@ -36,7 +36,7 @@ export const MarkerArrow: React.FC = () => {
             object={{
                 type: ObjectType.Arrow,
                 width: DEFAULT_ARROW_WIDTH,
-                height: DEFAULT_ARROW_HEIGHT,
+                length: DEFAULT_ARROW_LENGTH,
                 arrowEnd: true,
             }}
         />
@@ -51,7 +51,7 @@ registerDropHandler<ArrowObject>(ObjectType.Arrow, (object, position) => {
             color: DEFAULT_ARROW_COLOR,
             opacity: DEFAULT_ARROW_OPACITY,
             width: DEFAULT_ARROW_WIDTH,
-            height: DEFAULT_ARROW_HEIGHT,
+            length: DEFAULT_ARROW_LENGTH,
             rotation: 0,
             ...object,
             ...position,
@@ -59,56 +59,48 @@ registerDropHandler<ArrowObject>(ObjectType.Arrow, (object, position) => {
     };
 });
 
-const STROKE_WIDTH = DEFAULT_ARROW_WIDTH / 5;
-const POINTS = [DEFAULT_ARROW_WIDTH / 2, DEFAULT_ARROW_HEIGHT, DEFAULT_ARROW_WIDTH / 2, 0];
-
-const ArrowRenderer: React.FC<RendererProps<ArrowObject>> = ({ object }) => {
+const ArrowRenderer: React.FC<LineShapeRendererProps<ArrowObject>> = ({ object, length, width, rotation }) => {
     const highlightProps = useHighlightProps(object);
     const overrideProps = useOverrideProps(object);
+    const strokeWidth = width * ARROW_SHAFT_WIDTH_FRACTION;
 
-    const pointerLength = DEFAULT_ARROW_HEIGHT * 0.15;
-
-    // respect the stroke width when calculating the pointer size to avoid cropping
-    const extent = getArrowStrokeExtent(pointerLength, DEFAULT_ARROW_WIDTH, STROKE_WIDTH);
+    const pointerDimensions = getArrowPointerDimensions(width, ARROW_POINTER_BASE_ANGLE, strokeWidth);
 
     const arrowProps: ArrowConfig = {
-        points: POINTS,
-        width: DEFAULT_ARROW_WIDTH,
-        height: DEFAULT_ARROW_HEIGHT,
-        scaleX: object.width / DEFAULT_ARROW_WIDTH,
-        scaleY: object.height / DEFAULT_ARROW_HEIGHT,
-        pointerLength: pointerLength - extent.top - extent.bottom,
-        pointerWidth: DEFAULT_ARROW_WIDTH - extent.side * 2,
-        strokeWidth: STROKE_WIDTH,
+        points: [0, 0, 0, -length],
+        ...pointerDimensions,
+        strokeWidth,
         lineCap: 'round',
         pointerAtBeginning: !!object.arrowBegin,
         pointerAtEnding: !!object.arrowEnd,
     };
 
+    // The extra transparent `Rect` is to help select small arrows. The larger the arrow, the more
+    // confusing it is to select it by clicking empty space, so cap its size.
+    const dragAreaWidth = Math.min(DEFAULT_ARROW_WIDTH, width);
+
     return (
-        <ResizeableObjectContainer object={object} transformerProps={{ centeredScaling: true }}>
-            {(groupProps) => (
-                <Group {...groupProps} listening={!object.hide} {...overrideProps}>
-                    {highlightProps && (
-                        <Arrow
-                            {...arrowProps}
-                            {...highlightProps}
-                            strokeWidth={STROKE_WIDTH + (highlightProps.strokeWidth ?? 0)}
-                        />
-                    )}
-                    <Rect width={object.width} height={object.height} fill="transparent" />
-                    <HideCutoutGroup>
-                        <CompositeReplaceGroup enabled={!!highlightProps} opacity={object.opacity / 100}>
-                            <Arrow {...arrowProps} fill={object.color} stroke={object.color} />
-                        </CompositeReplaceGroup>
-                    </HideCutoutGroup>
-                </Group>
+        <Group listening={!object.hide} rotation={rotation} {...overrideProps}>
+            {highlightProps && (
+                <Arrow
+                    {...arrowProps}
+                    {...highlightProps}
+                    strokeWidth={strokeWidth + (highlightProps.strokeWidth ?? 0)}
+                />
             )}
-        </ResizeableObjectContainer>
+            <Rect width={dragAreaWidth} height={length} x={-dragAreaWidth / 2} y={-length} fill="transparent" />
+            <HideCutoutGroup>
+                <CompositeReplaceGroup enabled={!!highlightProps} opacity={object.opacity / 100}>
+                    <Arrow {...arrowProps} fill={object.color} stroke={object.color} />
+                </CompositeReplaceGroup>
+            </HideCutoutGroup>
+        </Group>
     );
 };
 
-registerRenderer<ArrowObject>(ObjectType.Arrow, LayerName.Default, ArrowRenderer);
+const ArrowContainer = createLineShapeContainer<ArrowObject>(ArrowRenderer, MIN_ARROW_WIDTH, MIN_ARROW_LENGTH);
+
+registerRenderer<ArrowObject>(ObjectType.Arrow, LayerName.Default, ArrowContainer);
 
 const ArrowDetails: React.FC<ListComponentProps<ArrowObject>> = (props) => {
     return <DetailsItem icon={<Icon color={props.object.color} />} name={NAME} {...props} />;

--- a/src/prefabs/Tethers.tsx
+++ b/src/prefabs/Tethers.tsx
@@ -180,9 +180,10 @@ const POINTER_LENGTH = 10;
 const POINTER_WIDTH = 10;
 
 const CloseTetherRenderer: React.FC<TetherProps> = ({ object, scene, highlightProps, startObject, endObject }) => {
+    const extent = getArrowStrokeExtent(POINTER_LENGTH, POINTER_WIDTH, object.width);
     const [start, end] = getTetherPoints(scene, startObject, endObject);
     const center = vecMult(vecAdd(start, end), 0.5);
-    const offset = vecMult(vecUnit(vecSub(end, start)), object.width * 1.25);
+    const offset = vecMult(vecUnit(vecSub(end, start)), extent.top);
 
     const c1 = vecSub(center, offset);
     const c2 = vecAdd(center, offset);
@@ -226,7 +227,7 @@ const FarTetherRenderer: React.FC<TetherProps> = ({ object, scene, highlightProp
     // Shrink the tether by the amount that the stroke extends past the tips of the arrows.
     const extent = getArrowStrokeExtent(POINTER_LENGTH, POINTER_WIDTH, object.width);
 
-    const [start, end] = getTetherPoints(scene, startObject, endObject, extent.top * 2);
+    const [start, end] = getTetherPoints(scene, startObject, endObject, extent.top);
 
     const arrowProps: ArrowConfig = {
         points: [start.x, start.y, end.x, end.y],

--- a/src/prefabs/lines.tsx
+++ b/src/prefabs/lines.tsx
@@ -1,0 +1,177 @@
+import React, { useState } from 'react';
+import { Circle, Rect } from 'react-konva';
+import { getAbsoluteRotation, getBaseFacingRotation, getPointerAngle, snapAngle } from '../coord';
+import { getResizeCursor } from '../cursor';
+import type { RendererProps } from '../render/ObjectRegistry';
+import { ActivePortal } from '../render/Portals';
+import type { LineProps, Scene, SceneObject } from '../scene';
+import { useScene } from '../SceneProvider';
+import { useIsDragging } from '../selection';
+import { CENTER_DOT_RADIUS } from '../theme';
+import { clampRotation, mod360, type Enum } from '../util';
+import { distance, getDistanceFromLine, VEC_ZERO, vecAtAngle } from '../vector';
+import {
+    CONTROL_POINT_BORDER_COLOR,
+    createControlPointManager,
+    HandleStyle,
+    type HandleFuncProps,
+} from './ControlPoint';
+import { DraggableObject } from './DraggableObject';
+import { useShowResizer } from './highlight';
+
+interface LineState {
+    length: number;
+    width: number;
+    rotation: number;
+}
+
+function lineStateChanged(object: LineProps, state: LineState) {
+    return (
+        state.length !== object.length ||
+        mod360(state.rotation) !== mod360(object.rotation) ||
+        state.width !== object.width
+    );
+}
+
+const HandleId = {
+    Length: 0,
+    Width: 1,
+} as const;
+type HandleId = Enum<typeof HandleId>;
+
+const ROTATE_SNAP_DIVISION = 15;
+const ROTATE_SNAP_TOLERANCE = 2;
+
+const OUTSET = 2;
+
+function getLength(object: LineProps, { pointerPos, activeHandleId }: HandleFuncProps, minLength: number) {
+    if (pointerPos && activeHandleId === HandleId.Length) {
+        return Math.max(minLength, Math.round(distance(pointerPos) - OUTSET));
+    }
+
+    return object.length;
+}
+
+function getRotation(scene: Readonly<Scene>, object: LineProps, { pointerPos, activeHandleId }: HandleFuncProps) {
+    if (pointerPos && activeHandleId === HandleId.Length) {
+        const angle = getPointerAngle(pointerPos);
+        const baseRotation = getBaseFacingRotation(scene, object);
+        return snapAngle(angle - baseRotation, ROTATE_SNAP_DIVISION, ROTATE_SNAP_TOLERANCE) + baseRotation;
+    }
+
+    return getAbsoluteRotation(scene, object);
+}
+
+function getWidth(
+    scene: Readonly<Scene>,
+    object: LineProps,
+    { pointerPos, activeHandleId }: HandleFuncProps,
+    minWidth: number,
+) {
+    if (pointerPos && activeHandleId == HandleId.Width) {
+        const start = VEC_ZERO;
+        const end = vecAtAngle(getAbsoluteRotation(scene, object));
+        const distance = getDistanceFromLine(start, end, pointerPos);
+
+        return Math.max(minWidth, Math.round(distance * 2));
+    }
+
+    return object.width;
+}
+
+/** Control points for line-shaped objects (rectangular, origin is on the center of an edge). */
+function createLineControlPoints(minWidth: number, minLength: number) {
+    return createControlPointManager<LineProps, LineState>({
+        handleFunc: (scene, object, handle) => {
+            const length = getLength(object, handle, minLength) + OUTSET;
+            const width = getWidth(scene, object, handle, minWidth);
+            const rotation = getRotation(scene, object, handle);
+
+            const x = width / 2;
+            const y = -length / 2;
+
+            return [
+                { id: HandleId.Length, style: HandleStyle.Square, cursor: getResizeCursor(rotation), x: 0, y: -length },
+                { id: HandleId.Width, style: HandleStyle.Diamond, cursor: getResizeCursor(rotation + 90), x: x, y: y },
+                { id: HandleId.Width, style: HandleStyle.Diamond, cursor: getResizeCursor(rotation + 90), x: -x, y: y },
+            ];
+        },
+        getRotation: getRotation,
+        stateFunc: (scene, object, handle) => {
+            const length = getLength(object, handle, minLength);
+            const width = getWidth(scene, object, handle, minWidth);
+            const rotation = getRotation(scene, object, handle);
+
+            return { length, width, rotation };
+        },
+        onRenderBorder: (object, state) => {
+            const strokeWidth = 1;
+            const width = state.width + strokeWidth * 2;
+            const length = state.length + strokeWidth * 2;
+
+            return (
+                <>
+                    <Rect
+                        x={-width / 2}
+                        y={-length + strokeWidth}
+                        width={width}
+                        height={length}
+                        stroke={CONTROL_POINT_BORDER_COLOR}
+                        strokeWidth={strokeWidth}
+                        fillEnabled={false}
+                    />
+                    <Circle radius={CENTER_DOT_RADIUS} fill={CONTROL_POINT_BORDER_COLOR} />
+                </>
+            );
+        },
+    });
+}
+
+export interface LineShapeRendererProps<T extends LineProps & SceneObject> extends RendererProps<T> {
+    length: number;
+    width: number;
+    rotation: number;
+    isDragging?: boolean;
+}
+
+export function createLineShapeContainer<T extends LineProps & SceneObject>(
+    LineShapeRenderer: React.FC<LineShapeRendererProps<T>>,
+    minWidth: number,
+    minLength: number,
+) {
+    const LineControlPoints = createLineControlPoints(minWidth, minLength);
+    const Container: React.FC<RendererProps<T>> = ({ object }) => {
+        const { dispatch, scene } = useScene();
+        const showResizer = useShowResizer(object);
+        const [resizing, setResizing] = useState(false);
+        const dragging = useIsDragging(object);
+
+        const updateObject = (state: LineState) => {
+            const baseRotation = getBaseFacingRotation(scene, object);
+            state.rotation = clampRotation(state.rotation - baseRotation);
+            state.width = Math.round(state.width);
+
+            if (!lineStateChanged(object, state)) {
+                return;
+            }
+
+            dispatch({ type: 'update', value: { ...object, ...state } });
+        };
+
+        return (
+            <ActivePortal isActive={dragging || resizing}>
+                <DraggableObject object={object}>
+                    <LineControlPoints
+                        object={object}
+                        onActive={setResizing}
+                        visible={showResizer && !dragging}
+                        onTransformEnd={updateObject}
+                    >
+                        {(props) => <LineShapeRenderer object={object} isDragging={dragging || resizing} {...props} />}
+                    </LineControlPoints>
+                </DraggableObject>
+            </ActivePortal>
+        );
+    };
+    return Container;
+}

--- a/src/prefabs/zone/ZoneLine.tsx
+++ b/src/prefabs/zone/ZoneLine.tsx
@@ -1,30 +1,16 @@
-import { useState } from 'react';
 import { Circle, Group, Rect } from 'react-konva';
 import Icon from '../../assets/zone/line.svg?react';
-import { getAbsoluteRotation, getBaseFacingRotation, getPointerAngle, snapAngle } from '../../coord';
-import { getResizeCursor } from '../../cursor';
 import { getDragOffset, registerDropHandler } from '../../DropHandler';
 import { DetailsItem } from '../../panel/DetailsItem';
 import { type ListComponentProps, registerListComponent } from '../../panel/ListComponentRegistry';
 import { LayerName } from '../../render/layers';
-import { registerRenderer, type RendererProps } from '../../render/ObjectRegistry';
-import { ActivePortal } from '../../render/Portals';
-import { type LineZone, ObjectType, type Scene } from '../../scene';
-import { useScene } from '../../SceneProvider';
-import { useIsDragging } from '../../selection';
+import { registerRenderer } from '../../render/ObjectRegistry';
+import { type LineZone, ObjectType } from '../../scene';
 import { CENTER_DOT_RADIUS, DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
-import { clampRotation, type Enum, mod360 } from '../../util';
-import { distance, getDistanceFromLine, VEC_ZERO, vecAtAngle } from '../../vector';
 import { MIN_LINE_LENGTH, MIN_LINE_WIDTH } from '../bounds';
-import {
-    CONTROL_POINT_BORDER_COLOR,
-    createControlPointManager,
-    type HandleFuncProps,
-    HandleStyle,
-} from '../ControlPoint';
-import { DraggableObject } from '../DraggableObject';
 import { HideGroup } from '../HideGroup';
-import { useHighlightProps, useOverrideProps, useShowResizer } from '../highlight';
+import { useHighlightProps, useOverrideProps } from '../highlight';
+import { createLineShapeContainer, type LineShapeRendererProps } from '../lines';
 import { PrefabIcon } from '../PrefabIcon';
 import { getZoneStyle } from './style';
 
@@ -83,106 +69,7 @@ const LineDetails: React.FC<ListComponentProps<LineZone>> = ({ object, ...props 
 
 registerListComponent<LineZone>(ObjectType.Line, LineDetails);
 
-const HandleId = {
-    Length: 0,
-    Width: 1,
-} as const;
-type HandleId = Enum<typeof HandleId>;
-
-interface LineState {
-    length: number;
-    width: number;
-    rotation: number;
-}
-
-const ROTATE_SNAP_DIVISION = 15;
-const ROTATE_SNAP_TOLERANCE = 2;
-
-const OUTSET = 2;
-
-function getLength(object: LineZone, { pointerPos, activeHandleId }: HandleFuncProps) {
-    if (pointerPos && activeHandleId === HandleId.Length) {
-        return Math.max(MIN_LINE_LENGTH, Math.round(distance(pointerPos) - OUTSET));
-    }
-
-    return object.length;
-}
-
-function getRotation(scene: Readonly<Scene>, object: LineZone, { pointerPos, activeHandleId }: HandleFuncProps) {
-    if (pointerPos && activeHandleId === HandleId.Length) {
-        const angle = getPointerAngle(pointerPos);
-        const baseRotation = getBaseFacingRotation(scene, object);
-        return snapAngle(angle - baseRotation, ROTATE_SNAP_DIVISION, ROTATE_SNAP_TOLERANCE) + baseRotation;
-    }
-
-    return getAbsoluteRotation(scene, object);
-}
-
-function getWidth(scene: Readonly<Scene>, object: LineZone, { pointerPos, activeHandleId }: HandleFuncProps) {
-    if (pointerPos && activeHandleId == HandleId.Width) {
-        const start = VEC_ZERO;
-        const end = vecAtAngle(getAbsoluteRotation(scene, object));
-        const distance = getDistanceFromLine(start, end, pointerPos);
-
-        return Math.max(MIN_LINE_WIDTH, Math.round(distance * 2));
-    }
-
-    return object.width;
-}
-
-const LineControlPoints = createControlPointManager<LineZone, LineState>({
-    handleFunc: (scene, object, handle) => {
-        const length = getLength(object, handle) + OUTSET;
-        const width = getWidth(scene, object, handle);
-        const rotation = getRotation(scene, object, handle);
-
-        const x = width / 2;
-        const y = -length / 2;
-
-        return [
-            { id: HandleId.Length, style: HandleStyle.Square, cursor: getResizeCursor(rotation), x: 0, y: -length },
-            { id: HandleId.Width, style: HandleStyle.Diamond, cursor: getResizeCursor(rotation + 90), x: x, y: y },
-            { id: HandleId.Width, style: HandleStyle.Diamond, cursor: getResizeCursor(rotation + 90), x: -x, y: y },
-        ];
-    },
-    getRotation: getRotation,
-    stateFunc: (scene, object, handle) => {
-        const length = getLength(object, handle);
-        const width = getWidth(scene, object, handle);
-        const rotation = getRotation(scene, object, handle);
-
-        return { length, width, rotation };
-    },
-    onRenderBorder: (object, state) => {
-        const strokeWidth = 1;
-        const width = state.width + strokeWidth * 2;
-        const length = state.length + strokeWidth * 2;
-
-        return (
-            <>
-                <Rect
-                    x={-width / 2}
-                    y={-length + strokeWidth}
-                    width={width}
-                    height={length}
-                    stroke={CONTROL_POINT_BORDER_COLOR}
-                    strokeWidth={strokeWidth}
-                    fillEnabled={false}
-                />
-                <Circle radius={CENTER_DOT_RADIUS} fill={CONTROL_POINT_BORDER_COLOR} />
-            </>
-        );
-    },
-});
-
-interface LineRendererProps extends RendererProps<LineZone> {
-    length: number;
-    width: number;
-    rotation: number;
-    isDragging?: boolean;
-}
-
-const LineRenderer: React.FC<LineRendererProps> = ({ object, length, width, rotation, isDragging }) => {
+const LineRenderer: React.FC<LineShapeRendererProps<LineZone>> = ({ object, length, width, rotation, isDragging }) => {
     const highlightProps = useHighlightProps(object);
     const overrideProps = useOverrideProps(object);
     const style = getZoneStyle(object.color, object.opacity, Math.min(length, width), object.hollow);
@@ -215,46 +102,6 @@ const LineRenderer: React.FC<LineRendererProps> = ({ object, length, width, rota
     );
 };
 
-function stateChanged(object: LineZone, state: LineState) {
-    return (
-        state.length !== object.length ||
-        mod360(state.rotation) !== mod360(object.rotation) ||
-        state.width !== object.width
-    );
-}
-
-const LineContainer: React.FC<RendererProps<LineZone>> = ({ object }) => {
-    const { dispatch, scene } = useScene();
-    const showResizer = useShowResizer(object);
-    const [resizing, setResizing] = useState(false);
-    const dragging = useIsDragging(object);
-
-    const updateObject = (state: LineState) => {
-        const baseRotation = getBaseFacingRotation(scene, object);
-        state.rotation = clampRotation(state.rotation - baseRotation);
-        state.width = Math.round(state.width);
-
-        if (!stateChanged(object, state)) {
-            return;
-        }
-
-        dispatch({ type: 'update', value: { ...object, ...state } });
-    };
-
-    return (
-        <ActivePortal isActive={dragging || resizing}>
-            <DraggableObject object={object}>
-                <LineControlPoints
-                    object={object}
-                    onActive={setResizing}
-                    visible={showResizer && !dragging}
-                    onTransformEnd={updateObject}
-                >
-                    {(props) => <LineRenderer object={object} isDragging={dragging || resizing} {...props} />}
-                </LineControlPoints>
-            </DraggableObject>
-        </ActivePortal>
-    );
-};
+const LineContainer = createLineShapeContainer(LineRenderer, MIN_LINE_WIDTH, MIN_LINE_LENGTH);
 
 registerRenderer<LineZone>(ObjectType.Line, LayerName.Ground, LineContainer);

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -199,7 +199,7 @@ export interface MarkerObject extends NamedObject, ImageObject, ColoredObject, B
 }
 export const isMarker = makeObjectTest<MarkerObject>(ObjectType.Marker);
 
-export interface ArrowObject extends ResizeableObject, ColoredObject, BaseObject {
+export interface ArrowObject extends LineProps, ColoredObject, BaseObject {
     readonly type: typeof ObjectType.Arrow;
     readonly arrowBegin?: boolean;
     readonly arrowEnd?: boolean;
@@ -293,6 +293,8 @@ export interface LineZone extends LineProps, BaseObject {
     readonly type: typeof ObjectType.Line;
 }
 export const isLineZone = makeObjectTest<LineZone>(ObjectType.Line);
+
+export const hasLineProperties = makeObjectTest<LineProps & UnknownObject>(ObjectType.Line, ObjectType.Arrow);
 
 export interface ConeProps extends RadiusObject, ColoredObject, HollowObject, RotateableObject {
     readonly coneAngle: number;


### PR DESCRIPTION
Addresses #84 and #36 by turning the Arrow object into something more like the Line zone rather than a Rectangle zone.

Additional effects:
* The object width now matches the width of the arrow pointers (when enabled), which now have a fixed shape instead of getting stretched.
* Old plans using arrows will look slightly different due to the change in rendering. The biggest difference will be for plans that have very wide arrow objects for some reason (which will get huge pointers instead of "just" very wide pointers)
* Like a line zone, arrows will now attach to objects if dragged on top (and reset to relative-(0,0) once connected)
* The hidden rectangle to help select the arrow object now has a maximum size; bigger arrows don't need the increased click surface.


Since I had a diagram for it anyway (https://www.geogebra.org/geometry/yr6pha93 for a digital version), this also fixes the calculations used in 1186bdf to have tether arrow pointers line up better.