### PR TITLE
Add support for steps having a custom arena

### DIFF
--- a/src/HotkeyHandler.tsx
+++ b/src/HotkeyHandler.tsx
@@ -14,6 +14,7 @@ import { moveObjectsBy } from './groupOperations';
 import { makeTethers } from './prefabs/TetherConfig';
 import { useStage } from './render/stage';
 import {
+    type Arena,
     type MoveableObject,
     type Scene,
     type SceneObject,
@@ -61,6 +62,7 @@ const UndoRedoHandler: React.FC = () => {
 function pasteObjects(
     stage: Stage,
     scene: Scene,
+    arena: Arena,
     step: SceneStep,
     dispatch: Dispatch<SceneAction>,
     setSelection: Dispatch<SetStateAction<SceneSelection>>,
@@ -72,7 +74,7 @@ function pasteObjects(
     }
 
     const pointerPosition = stage.getRelativePointerPosition() ?? { x: 0, y: 0 };
-    const newCenter = centerOnMouse ? getSceneCoord(scene, pointerPosition) : undefined;
+    const newCenter = centerOnMouse ? getSceneCoord(scene, arena, pointerPosition) : undefined;
     const { objects: newObjects } = copyObjects(scene, step, objects, newCenter);
 
     if (newObjects.length) {
@@ -146,7 +148,7 @@ const SelectionActionHandler: React.FC = () => {
     const [selection, setSelection] = useSelection();
     const [editMode, setEditMode] = useEditMode();
     const [tetherConfig, setTetherConfig] = useTetherConfig();
-    const { scene, step, dispatch } = useScene();
+    const { scene, step, arena, dispatch } = useScene();
     const stage = useStage();
 
     useHotkeys(
@@ -233,7 +235,7 @@ const SelectionActionHandler: React.FC = () => {
             e.preventDefault();
 
             const clipboard = await getClipboard(clipboardFallback);
-            pasteObjects(stage, scene, step, dispatch, setSelection, clipboard);
+            pasteObjects(stage, scene, arena, step, dispatch, setSelection, clipboard);
         },
         [stage, scene, step, dispatch, setSelection, editMode, clipboardFallback],
     );
@@ -248,7 +250,7 @@ const SelectionActionHandler: React.FC = () => {
             e.preventDefault();
 
             const clipboard = await getClipboard(clipboardFallback);
-            pasteObjects(stage, scene, step, dispatch, setSelection, clipboard, false);
+            pasteObjects(stage, scene, arena, step, dispatch, setSelection, clipboard, false);
         },
         [stage, scene, step, dispatch, setSelection, editMode, clipboardFallback],
     );
@@ -260,7 +262,7 @@ const SelectionActionHandler: React.FC = () => {
             if (!selection.size || !stage || editMode !== EditMode.Normal) {
                 return;
             }
-            pasteObjects(stage, scene, step, dispatch, setSelection, getSelectedObjects(step, selection), false);
+            pasteObjects(stage, scene, arena, step, dispatch, setSelection, getSelectedObjects(step, selection), false);
             e.preventDefault();
         },
         [stage, scene, step, dispatch, selection, setSelection, editMode],

--- a/src/SceneProvider.tsx
+++ b/src/SceneProvider.tsx
@@ -27,17 +27,30 @@ import type { StateActionBase, UndoRedoAction } from './undo/undoReducer';
 import { useSetSavedState } from './useIsDirty';
 import { asArray, clamp, omit } from './util';
 
+/**
+ * Overwrites either the shared arena in Scene, or the custom arena in the current SceneStep if there is one.
+ */
 export interface SetArenaAction {
     type: 'setArena';
     value: Arena;
 }
 
+/**
+ * Mutates either the shared arena in Scene, or the custom arena in the current SceneStep if there is one.
+ */
 export interface UpdateArenaAction {
     type: 'updateArena';
     value: Partial<Arena>;
 }
 
-export type ArenaAction = SetArenaAction | UpdateArenaAction;
+/** Enables or disables a specific step having a custom arena setting. On enabling, the global arena setting is copied. */
+export interface SetCustomArenaAction {
+    type: 'customArena';
+    stepIndex: number;
+    enable: boolean;
+}
+
+export type ArenaAction = SetArenaAction | UpdateArenaAction | SetCustomArenaAction;
 
 /**
  * Action which replaces existing objects with the given ones. Objects to replace are matched by ID.
@@ -180,6 +193,7 @@ export const SceneContext = Context;
 export interface SceneContext {
     scene: Scene;
     step: SceneStep;
+    arena: Arena;
     stepIndex: number;
     source?: FileSource;
     dispatch: React.Dispatch<SceneAction | UndoRedoAction<EditorState>>;
@@ -192,10 +206,12 @@ export function useScene(): SceneContext {
     const [transientPresent, present, dispatch] = usePresent();
     const [source] = use(SourceContext);
 
+    const currentStep = getCurrentStep(transientPresent);
     return {
         scene: transientPresent.scene,
         canonicalScene: present.scene,
-        step: getCurrentStep(transientPresent),
+        step: currentStep,
+        arena: currentStep.customArena ?? transientPresent.scene.arena,
         stepIndex: transientPresent.currentStep,
         source: source,
         dispatch,
@@ -317,9 +333,10 @@ function setStep(state: Readonly<EditorState>, index: number): EditorState {
 }
 
 function addStep(state: Readonly<EditorState>, after: number): EditorState {
-    const { objects, nextId } = copyObjects(state.scene, undefined, getCurrentStep(state).objects);
+    const currentStep = getCurrentStep(state);
+    const { objects, nextId } = copyObjects(state.scene, undefined, currentStep.objects);
 
-    const newStep: SceneStep = { objects };
+    const newStep: SceneStep = { objects, customArena: currentStep.customArena };
 
     const steps = state.scene.steps.slice();
     steps.splice(after + 1, 0, newStep);
@@ -430,7 +447,7 @@ function addObjects(
     return {
         ...state,
         scene: {
-            ...updateStep(state.scene, state.currentStep, { objects: newObjects }),
+            ...updateStep(state.scene, state.currentStep, { ...currentStep, objects: newObjects }),
             nextId,
         },
     };
@@ -488,7 +505,7 @@ function removeObjects(state: Readonly<EditorState>, ids: readonly number[]): Ed
                 : obj,
         );
 
-    return updateCurrentStep(state, { objects });
+    return updateCurrentStep(state, { ...currentStep, objects });
 }
 
 function moveObject(state: Readonly<EditorState>, from: number, to: number): EditorState {
@@ -502,7 +519,7 @@ function moveObject(state: Readonly<EditorState>, from: number, to: number): Edi
     const items = objects.splice(from, 1);
     objects.splice(to, 0, ...items);
 
-    return updateCurrentStep(state, { objects });
+    return updateCurrentStep(state, { ...currentStep, objects });
 }
 
 function mapSelected(step: Readonly<SceneStep>, ids: readonly number[]) {
@@ -582,10 +599,20 @@ function updateObjects(state: Readonly<EditorState>, values: readonly SceneObjec
         }
     }
 
-    return updateCurrentStep(state, { objects });
+    return updateCurrentStep(state, { ...currentStep, objects });
 }
 
 function setArena(state: Readonly<EditorState>, arena: Arena): EditorState {
+    const currentStep = state.scene.steps[state.currentStep];
+    if (currentStep?.customArena !== undefined) {
+        return {
+            scene: updateStep(state.scene, state.currentStep, {
+                ...currentStep,
+                customArena: arena,
+            }),
+            currentStep: state.currentStep,
+        };
+    }
     return {
         scene: { ...state.scene, arena },
         currentStep: state.currentStep,
@@ -593,8 +620,20 @@ function setArena(state: Readonly<EditorState>, arena: Arena): EditorState {
 }
 
 function updateArena(state: Readonly<EditorState>, arena: Partial<Arena>): EditorState {
+    const currentStep = state.scene.steps[state.currentStep];
+    return setArena(state, { ...(currentStep?.customArena ?? state.scene.arena), ...arena });
+}
+
+function setCustomArena(state: Readonly<EditorState>, stepIndex: number, enableCustomArena: boolean): EditorState {
+    const step = state.scene.steps[stepIndex];
+    if (!step) {
+        return state;
+    }
+    const newStepValue: SceneStep = enableCustomArena
+        ? { ...step, customArena: state.scene.arena }
+        : omit(step, 'customArena');
     return {
-        scene: { ...state.scene, arena: { ...state.scene.arena, ...arena } },
+        scene: updateStep(state.scene, stepIndex, newStepValue),
         currentStep: state.currentStep,
     };
 }
@@ -630,6 +669,9 @@ function sceneReducer(state: Readonly<EditorState>, action: SceneAction): Editor
 
         case 'updateArena':
             return updateArena(state, action.value);
+
+        case 'customArena':
+            return setCustomArena(state, action.stepIndex, action.enable);
 
         case 'add':
             return addObjects(state, action.object);

--- a/src/SceneProvider.tsx
+++ b/src/SceneProvider.tsx
@@ -11,9 +11,7 @@ import { getAbsolutePosition, getAbsoluteRotation } from './coord';
 import { copyObjects } from './copy';
 import {
     type Arena,
-    ArenaShape,
     DEFAULT_SCENE,
-    type Grid,
     isMoveable,
     isRotateable,
     isTether,
@@ -23,7 +21,6 @@ import {
     type SceneObjectWithoutId,
     type SceneStep,
     type Tether,
-    type Ticks,
 } from './scene';
 import { createUndoContext } from './undo/undoContext';
 import type { StateActionBase, UndoRedoAction } from './undo/undoReducer';
@@ -31,60 +28,16 @@ import { useSetSavedState } from './useIsDirty';
 import { asArray, clamp, omit } from './util';
 
 export interface SetArenaAction {
-    type: 'arena';
+    type: 'setArena';
     value: Arena;
 }
 
-export interface SetArenaShapeAction {
-    type: 'arenaShape';
-    value: ArenaShape;
+export interface UpdateArenaAction {
+    type: 'updateArena';
+    value: Partial<Arena>;
 }
 
-export interface SetArenaWidthAction {
-    type: 'arenaWidth';
-    value: number;
-}
-
-export interface SetArenaHeightAction {
-    type: 'arenaHeight';
-    value: number;
-}
-
-export interface SetArenaPaddingAction {
-    type: 'arenaPadding';
-    value: number;
-}
-
-export interface SetArenaGridAction {
-    type: 'arenaGrid';
-    value: Grid;
-}
-
-export interface SetArenaTicksActions {
-    type: 'arenaTicks';
-    value: Ticks;
-}
-
-export interface SetArenaBackgroundAction {
-    type: 'arenaBackground';
-    value: string | undefined;
-}
-
-export interface SetArenaBackgroundOpacityAction {
-    type: 'arenaBackgroundOpacity';
-    value: number;
-}
-
-export type ArenaAction =
-    | SetArenaAction
-    | SetArenaShapeAction
-    | SetArenaWidthAction
-    | SetArenaHeightAction
-    | SetArenaPaddingAction
-    | SetArenaGridAction
-    | SetArenaTicksActions
-    | SetArenaBackgroundAction
-    | SetArenaBackgroundOpacityAction;
+export type ArenaAction = SetArenaAction | UpdateArenaAction;
 
 /**
  * Action which replaces existing objects with the given ones. Objects to replace are matched by ID.
@@ -632,9 +585,16 @@ function updateObjects(state: Readonly<EditorState>, values: readonly SceneObjec
     return updateCurrentStep(state, { objects });
 }
 
-function updateArena(state: Readonly<EditorState>, arena: Arena): EditorState {
+function setArena(state: Readonly<EditorState>, arena: Arena): EditorState {
     return {
         scene: { ...state.scene, arena },
+        currentStep: state.currentStep,
+    };
+}
+
+function updateArena(state: Readonly<EditorState>, arena: Partial<Arena>): EditorState {
+    return {
+        scene: { ...state.scene, arena: { ...state.scene.arena, ...arena } },
         currentStep: state.currentStep,
     };
 }
@@ -665,32 +625,11 @@ function sceneReducer(state: Readonly<EditorState>, action: SceneAction): Editor
         case 'reoderSteps':
             return reoderSteps(state, action.order);
 
-        case 'arena':
+        case 'setArena':
+            return setArena(state, action.value);
+
+        case 'updateArena':
             return updateArena(state, action.value);
-
-        case 'arenaShape':
-            return updateArena(state, { ...state.scene.arena, shape: action.value });
-
-        case 'arenaWidth':
-            return updateArena(state, { ...state.scene.arena, width: action.value });
-
-        case 'arenaHeight':
-            return updateArena(state, { ...state.scene.arena, height: action.value });
-
-        case 'arenaPadding':
-            return updateArena(state, { ...state.scene.arena, padding: action.value });
-
-        case 'arenaGrid':
-            return updateArena(state, { ...state.scene.arena, grid: action.value });
-
-        case 'arenaTicks':
-            return updateArena(state, { ...state.scene.arena, ticks: action.value });
-
-        case 'arenaBackground':
-            return updateArena(state, { ...state.scene.arena, backgroundImage: action.value });
-
-        case 'arenaBackgroundOpacity':
-            return updateArena(state, { ...state.scene.arena, backgroundOpacity: action.value });
 
         case 'add':
             return addObjects(state, action.object);

--- a/src/StepScreenshotButton.tsx
+++ b/src/StepScreenshotButton.tsx
@@ -151,9 +151,10 @@ interface ScreenshotComponentProps {
 
 const ScreenshotComponent: React.FC<ScreenshotComponentProps> = ({ scale, onScreenshotDone }) => {
     const { isLoading } = use(ObjectLoadingContext);
-    const { scene, stepIndex } = useScene();
+    const { scene, arena, stepIndex } = useScene();
     const [frozenScene] = useState(scene);
     const [frozenStepIndex] = useState(stepIndex);
+    const [frozenArena] = useState(arena);
     const ref = useRef<Konva.Stage>(null);
 
     // https://github.com/reactwg/react-compiler/discussions/18
@@ -192,12 +193,13 @@ const ScreenshotComponent: React.FC<ScreenshotComponentProps> = ({ scale, onScre
         }
     }, [firstRender, isLoading, takeScreenshot]);
 
-    const size = getCanvasSize(frozenScene);
+    const size = getCanvasSize(frozenArena);
 
     return (
         <ScenePreview
             ref={ref}
             scene={frozenScene}
+            arena={frozenArena}
             stepIndex={frozenStepIndex}
             width={size.width}
             height={size.height}

--- a/src/StepSelect.tsx
+++ b/src/StepSelect.tsx
@@ -40,7 +40,7 @@ import { useCancelConnectionSelection } from './useEditMode';
 
 export const StepSelect: React.FC = () => {
     const classes = useStyles();
-    const { scene, stepIndex, dispatch } = useScene();
+    const { scene, arena, stepIndex, dispatch } = useScene();
     const cancelConnectionSelection = useCancelConnectionSelection();
     const steps = scene.steps.map((_, i) => i);
 
@@ -50,7 +50,7 @@ export const StepSelect: React.FC = () => {
         dispatch({ type: 'setStep', index });
     };
 
-    const maxWidth = scene.arena.width + scene.arena.padding * 2;
+    const maxWidth = arena.width + arena.padding * 2;
 
     return (
         <div className={classes.root} style={{ maxWidth }}>
@@ -290,6 +290,7 @@ const StepItem: React.FC<StepItemProps> = ({ ref, scene, step, className, ...pro
             <div className={classes.stepHeader}>{stepText}</div>
             <ScenePreview
                 scene={scene}
+                arena={scene.steps[step.index]?.customArena ?? scene.arena}
                 stepIndex={step.index}
                 width={PREVIEW_SIZE}
                 height={PREVIEW_SIZE}

--- a/src/coord.ts
+++ b/src/coord.ts
@@ -4,6 +4,7 @@ import { getObjectById, useScene } from './SceneProvider';
 import {
     isMoveable,
     isRotateable,
+    type Arena,
     type MoveableObject,
     type RotateableObject,
     type Scene,
@@ -23,13 +24,13 @@ export interface Position {
     readonly positionParentId?: number;
 }
 
-export function getCanvasX(scene: Scene, x: number): number {
-    const center = scene.arena.width / 2 + scene.arena.padding;
+export function getCanvasX(arena: Arena, x: number): number {
+    const center = arena.width / 2 + arena.padding;
     return center + x;
 }
 
-export function getCanvasY(scene: Scene, y: number): number {
-    const center = scene.arena.height / 2 + scene.arena.padding;
+export function getCanvasY(arena: Arena, y: number): number {
+    const center = arena.height / 2 + arena.padding;
     return center - y;
 }
 
@@ -62,62 +63,68 @@ export function getAbsolutePosition(scene: Scene, p: Position): Vector2d {
     return { x: parent.x + p.x, y: parent.y + p.y };
 }
 
-export function getCanvasCoord(scene: Scene, p: Position): Vector2d {
+export function getCanvasCoord(scene: Scene, arena: Arena, p: Position): Vector2d {
     const absolutePos = getAbsolutePosition(scene, p);
-    return { x: getCanvasX(scene, absolutePos.x), y: getCanvasY(scene, absolutePos.y) };
+    return { x: getCanvasX(arena, absolutePos.x), y: getCanvasY(arena, absolutePos.y) };
 }
 
-export function getCanvasSize(scene: Scene): { width: number; height: number } {
+export function getCanvasSize(arena: Arena): { width: number; height: number } {
     return {
-        width: scene.arena.width + scene.arena.padding * 2,
-        height: scene.arena.height + scene.arena.padding * 2,
+        width: arena.width + arena.padding * 2,
+        height: arena.height + arena.padding * 2,
     };
 }
 
-export function getCanvasArenaRect(scene: Scene): { x: number; y: number; width: number; height: number } {
-    const { x, y } = getCanvasCoord(scene, { x: -scene.arena.width / 2, y: scene.arena.height / 2 });
-    const width = scene.arena.width;
-    const height = scene.arena.height;
+export function getCanvasArenaRect(
+    scene: Scene,
+    arena: Arena,
+): { x: number; y: number; width: number; height: number } {
+    const { x, y } = getCanvasCoord(scene, arena, { x: -arena.width / 2, y: arena.height / 2 });
+    const width = arena.width;
+    const height = arena.height;
 
     return { x, y, width, height };
 }
 
-export function getCanvasArenaEllipse(scene: Scene): { x: number; y: number; radiusX: number; radiusY: number } {
-    const { x, y } = getCanvasCoord(scene, { x: 0, y: 0 });
-    const radiusX = scene.arena.width / 2;
-    const radiusY = scene.arena.height / 2;
+export function getCanvasArenaEllipse(
+    scene: Scene,
+    arena: Arena,
+): { x: number; y: number; radiusX: number; radiusY: number } {
+    const { x, y } = getCanvasCoord(scene, arena, { x: 0, y: 0 });
+    const radiusX = arena.width / 2;
+    const radiusY = arena.height / 2;
 
     return { x, y, radiusX, radiusY };
 }
 
 export function useCanvasCoord(p: Position): Vector2d {
-    const { scene } = useScene();
-    return getCanvasCoord(scene, p);
+    const { scene, arena } = useScene();
+    return getCanvasCoord(scene, arena, p);
 }
 
 export function useCanvasArenaRect(): { x: number; y: number; width: number; height: number } {
-    const { scene } = useScene();
-    return getCanvasArenaRect(scene);
+    const { scene, arena } = useScene();
+    return getCanvasArenaRect(scene, arena);
 }
 
 export function useCanvasArenaEllipse(): { x: number; y: number; radiusX: number; radiusY: number } {
-    const { scene } = useScene();
-    return getCanvasArenaEllipse(scene);
+    const { scene, arena } = useScene();
+    return getCanvasArenaEllipse(scene, arena);
 }
 
-export function getSceneX(scene: Scene, x: number): number {
-    const center = scene.arena.width / 2 + scene.arena.padding;
+function getArenaX(arena: Arena, x: number): number {
+    const center = arena.width / 2 + arena.padding;
     return x - center;
 }
 
-export function getSceneY(scene: Scene, y: number): number {
-    const center = scene.arena.height / 2 + scene.arena.padding;
+function getArenaY(arena: Arena, y: number): number {
+    const center = arena.height / 2 + arena.padding;
     return center - y;
 }
 
-export function getSceneCoord(scene: Scene, p: Position): Vector2d {
+export function getSceneCoord(scene: Scene, arena: Arena, p: Position): Vector2d {
     const absolutePos = getAbsolutePosition(scene, p);
-    return round({ x: getSceneX(scene, absolutePos.x), y: getSceneY(scene, absolutePos.y) });
+    return round({ x: getArenaX(arena, absolutePos.x), y: getArenaY(arena, absolutePos.y) });
 }
 
 /**
@@ -188,12 +195,12 @@ export function getPointerAngle(pos: Vector2d): number {
     return vecAngle(pos);
 }
 
-export function getPointerPosition(scene: Scene, stage: Stage | undefined | null): Vector2d | null {
+export function getPointerPosition(scene: Scene, arena: Arena, stage: Stage | undefined | null): Vector2d | null {
     const pos = stage?.getPointerPosition();
     if (!pos) {
         return null;
     }
-    return getSceneCoord(scene, pos);
+    return getSceneCoord(scene, arena, pos);
 }
 
 export interface Circle {

--- a/src/panel/ArenaBackgroundEdit.tsx
+++ b/src/panel/ArenaBackgroundEdit.tsx
@@ -5,22 +5,22 @@ import { OpacitySlider } from '../OpacitySlider';
 import { useScene } from '../SceneProvider';
 
 export const ArenaBackgroundEdit: React.FC = () => {
-    const { scene, dispatch } = useScene();
+    const { arena, dispatch } = useScene();
     return (
         <>
             <Field label="Background image URL">
                 <DeferredInput
-                    value={scene.arena.backgroundImage}
+                    value={arena.backgroundImage}
                     onChange={(ev, data) => {
                         dispatch({ type: 'updateArena', value: { backgroundImage: data.value }, transient: true });
                     }}
                     onCommit={() => dispatch({ type: 'commit' })}
                 />
             </Field>
-            {scene.arena.backgroundImage && (
+            {arena.backgroundImage && (
                 <OpacitySlider
                     label="Background image opacity"
-                    value={scene.arena.backgroundOpacity ?? 100}
+                    value={arena.backgroundOpacity ?? 100}
                     onChange={(ev, data) => {
                         dispatch({
                             type: 'updateArena',

--- a/src/panel/ArenaBackgroundEdit.tsx
+++ b/src/panel/ArenaBackgroundEdit.tsx
@@ -12,7 +12,7 @@ export const ArenaBackgroundEdit: React.FC = () => {
                 <DeferredInput
                     value={scene.arena.backgroundImage}
                     onChange={(ev, data) => {
-                        dispatch({ type: 'arenaBackground', value: data.value, transient: true });
+                        dispatch({ type: 'updateArena', value: { backgroundImage: data.value }, transient: true });
                     }}
                     onCommit={() => dispatch({ type: 'commit' })}
                 />
@@ -22,7 +22,11 @@ export const ArenaBackgroundEdit: React.FC = () => {
                     label="Background image opacity"
                     value={scene.arena.backgroundOpacity ?? 100}
                     onChange={(ev, data) => {
-                        dispatch({ type: 'arenaBackgroundOpacity', value: data.value, transient: data.transient });
+                        dispatch({
+                            type: 'updateArena',
+                            value: { backgroundOpacity: data.value },
+                            transient: data.transient,
+                        });
                     }}
                     onCommit={() => dispatch({ type: 'commit' })}
                 />

--- a/src/panel/ArenaGridEdit.tsx
+++ b/src/panel/ArenaGridEdit.tsx
@@ -84,7 +84,7 @@ export const ArenaGridEdit: React.FC = () => {
     const grid = scene.arena.grid;
 
     const setGrid = (grid: Grid, transient = false) => {
-        dispatch({ type: 'arenaGrid', value: grid, transient });
+        dispatch({ type: 'updateArena', value: { grid }, transient });
     };
 
     const commit = () => dispatch({ type: 'commit' });

--- a/src/panel/ArenaGridEdit.tsx
+++ b/src/panel/ArenaGridEdit.tsx
@@ -80,8 +80,8 @@ function didCustomRadialGridChange(grid: CustomRadialGrid, ringsText: string, sp
 
 export const ArenaGridEdit: React.FC = () => {
     const classes = useControlStyles();
-    const { scene, dispatch } = useScene();
-    const grid = scene.arena.grid;
+    const { arena, dispatch } = useScene();
+    const grid = arena.grid;
 
     const setGrid = (grid: Grid, transient = false) => {
         dispatch({ type: 'updateArena', value: { grid }, transient });

--- a/src/panel/ArenaPanel.tsx
+++ b/src/panel/ArenaPanel.tsx
@@ -131,7 +131,7 @@ const PresetsDialogBody: React.FC<PresetsDialogBodyProps> = ({ setOpen }) => {
     });
 
     const applyPreset = (preset: ArenaPreset) => {
-        dispatch({ type: 'arena', value: preset.arena });
+        dispatch({ type: 'setArena', value: preset.arena });
         setOpen(false);
     };
 

--- a/src/panel/ArenaPanel.tsx
+++ b/src/panel/ArenaPanel.tsx
@@ -16,6 +16,7 @@ import {
     NavItem,
     NavSectionHeader,
     shorthands,
+    Switch,
     tokens,
     typographyStyles,
     useArrowNavigationGroup,
@@ -77,9 +78,28 @@ export const ArenaPanel: React.FC = () => {
             <ArenaGridEdit />
             <ArenaTickEdit />
             <ArenaBackgroundEdit />
+            <CustomArenaToggle />
             <Divider />
             <SelectPresetButton />
         </div>
+    );
+};
+
+const CustomArenaToggle: React.FC = () => {
+    const { scene, stepIndex, dispatch } = useScene();
+    const hasCustomArena = scene.steps[stepIndex]?.customArena !== undefined;
+
+    const toggleCustomArena = () => {
+        dispatch({ type: 'customArena', stepIndex, enable: !hasCustomArena });
+    };
+
+    return (
+        <Switch
+            size="small"
+            label={'Use a custom arena on this step'}
+            onChange={toggleCustomArena}
+            checked={hasCustomArena}
+        />
     );
 };
 
@@ -289,6 +309,7 @@ const PresetItem: React.FC<PresetItemProps> = ({
                 <div className={mergeClasses(classes.arenaPreview, isSpoiler && classes.blur)}>
                     <ScenePreview
                         scene={scene}
+                        arena={preset.arena}
                         width={PREVIEW_SIZE}
                         height={PREVIEW_SIZE}
                         backgroundColor="transparent"

--- a/src/panel/ArenaShapeEdit.tsx
+++ b/src/panel/ArenaShapeEdit.tsx
@@ -21,8 +21,8 @@ const BorderNoneIcon = bundleIcon(BorderNoneFilled, BorderNoneRegular);
 
 export const ArenaShapeEdit: React.FC = () => {
     const classes = useControlStyles();
-    const { scene, dispatch } = useScene();
-    const { shape, width, height, padding } = scene.arena;
+    const { arena, dispatch } = useScene();
+    const { shape, width, height, padding } = arena;
 
     const onWidthChanged = (value: number) => dispatch({ type: 'updateArena', value: { width: value } });
     const onHeightChanged = (value: number) => dispatch({ type: 'updateArena', value: { height: value } });

--- a/src/panel/ArenaShapeEdit.tsx
+++ b/src/panel/ArenaShapeEdit.tsx
@@ -24,9 +24,9 @@ export const ArenaShapeEdit: React.FC = () => {
     const { scene, dispatch } = useScene();
     const { shape, width, height, padding } = scene.arena;
 
-    const onWidthChanged = (value: number) => dispatch({ type: 'arenaWidth', value });
-    const onHeightChanged = (value: number) => dispatch({ type: 'arenaHeight', value });
-    const onPaddingChanged = (value: number) => dispatch({ type: 'arenaPadding', value });
+    const onWidthChanged = (value: number) => dispatch({ type: 'updateArena', value: { width: value } });
+    const onHeightChanged = (value: number) => dispatch({ type: 'updateArena', value: { height: value } });
+    const onPaddingChanged = (value: number) => dispatch({ type: 'updateArena', value: { padding: value } });
 
     return (
         <div className={classes.column}>
@@ -35,7 +35,9 @@ export const ArenaShapeEdit: React.FC = () => {
                     <SegmentedGroup
                         name="arena-shape"
                         value={shape}
-                        onChange={(ev, data) => dispatch({ type: 'arenaShape', value: data.value as ArenaShape })}
+                        onChange={(ev, data) =>
+                            dispatch({ type: 'updateArena', value: { shape: data.value as ArenaShape } })
+                        }
                     >
                         <Segment value={ArenaShape.None} icon={<BorderNoneIcon />} title="None" />
                         <Segment value={ArenaShape.Circle} icon={<CircleIcon />} title="Circle" />

--- a/src/panel/ArenaTickEdit.tsx
+++ b/src/panel/ArenaTickEdit.tsx
@@ -22,8 +22,8 @@ const SquareIcon = bundleIcon(SquareFilled, SquareRegular);
 
 export const ArenaTickEdit: React.FC = () => {
     const classes = useControlStyles();
-    const { scene, dispatch } = useScene();
-    const ticks = scene.arena.ticks;
+    const { arena, dispatch } = useScene();
+    const ticks = arena.ticks;
 
     const setTicks = (ticks: Ticks) => {
         dispatch({ type: 'updateArena', value: { ticks } });

--- a/src/panel/ArenaTickEdit.tsx
+++ b/src/panel/ArenaTickEdit.tsx
@@ -26,7 +26,7 @@ export const ArenaTickEdit: React.FC = () => {
     const ticks = scene.arena.ticks;
 
     const setTicks = (ticks: Ticks) => {
-        dispatch({ type: 'arenaTicks', value: ticks });
+        dispatch({ type: 'updateArena', value: { ticks } });
     };
 
     const onTypeChange = (option?: TickType) => {

--- a/src/prefabs/ControlPoint.tsx
+++ b/src/prefabs/ControlPoint.tsx
@@ -98,7 +98,7 @@ export function createControlPointManager<T extends Vector2d, S, P = unknown>(
     const ControlPointManager: React.FC<ControlPointManagerProps<T, S, P>> = (props) => {
         const { children, onActive, onTransformEnd, object, visible } = props;
 
-        const { scene } = useScene();
+        const { scene, arena } = useScene();
         const stage = useStage();
         const [transform, setTransform] = useState<TransformState>();
         const groupRef = useRef<Konva.Group>(null);
@@ -192,7 +192,7 @@ export function createControlPointManager<T extends Vector2d, S, P = unknown>(
             }
         };
 
-        const center = getCanvasCoord(scene, object);
+        const center = getCanvasCoord(scene, arena, object);
 
         return (
             <>

--- a/src/prefabs/DraggableObject.tsx
+++ b/src/prefabs/DraggableObject.tsx
@@ -5,8 +5,8 @@ import { getCanvasCoord, getSceneCoord, makeRelative } from '../coord';
 import { CursorGroup } from '../CursorGroup';
 import { EditMode } from '../editMode';
 import { moveObjectsBy } from '../groupOperations';
-import { isMoveable, type MoveableObject, type Scene, type SceneStep, type UnknownObject } from '../scene';
-import { type SceneAction, useScene } from '../SceneProvider';
+import { isMoveable, type Arena, type MoveableObject, type Scene, type SceneStep, type UnknownObject } from '../scene';
+import { useScene, type SceneAction } from '../SceneProvider';
 import {
     getNewDragSelection,
     getSelectedObjects,
@@ -28,10 +28,10 @@ export interface DraggableObjectProps {
 
 export const DraggableObject: React.FC<DraggableObjectProps> = ({ object, children }) => {
     const [editMode] = useEditMode();
-    const { scene, step, dispatch } = useScene();
+    const { scene, step, arena, dispatch } = useScene();
     const [selection, setSelection] = useSelection();
     const [dragSelection, setDragSelection] = useDragSelection();
-    const center = getCanvasCoord(scene, object);
+    const center = getCanvasCoord(scene, arena, object);
 
     const isDraggable = !object.pinned && editMode === EditMode.Normal;
 
@@ -52,15 +52,15 @@ export const DraggableObject: React.FC<DraggableObjectProps> = ({ object, childr
 
         setDragSelection(newSelection);
 
-        updatePosition(scene, step, object, dragSelection, e, dispatch);
+        updatePosition(scene, arena, step, object, dragSelection, e, dispatch);
     };
 
     const handleDragMove = (e: KonvaEventObject<DragEvent>) => {
-        updatePosition(scene, step, object, dragSelection, e, dispatch);
+        updatePosition(scene, arena, step, object, dragSelection, e, dispatch);
     };
 
     const handleDragEnd = (e: KonvaEventObject<DragEvent>) => {
-        updatePosition(scene, step, object, dragSelection, e, dispatch);
+        updatePosition(scene, arena, step, object, dragSelection, e, dispatch);
         dispatch({ type: 'commit' });
 
         setDragSelection(selectNone());
@@ -90,6 +90,7 @@ export const DraggableObject: React.FC<DraggableObjectProps> = ({ object, childr
 
 function updatePosition(
     scene: Scene,
+    arena: Arena,
     step: SceneStep,
     targetObject: MoveableObject & UnknownObject,
     dragSelection: SceneSelection,
@@ -99,7 +100,7 @@ function updatePosition(
     // Konva automatically moves the object to e.target.position() in canvas
     // coordinates. Subtracting the object's original position gives the offset
     // that needs to be applied to all objects being dragged.
-    const pos = makeRelative(scene, getSceneCoord(scene, e.target.position()), targetObject.positionParentId);
+    const pos = makeRelative(scene, getSceneCoord(scene, arena, e.target.position()), targetObject.positionParentId);
     const offset = vecSub(pos, targetObject);
 
     if (offset.x === 0 && offset.y === 0) {

--- a/src/prefabs/Tethers.tsx
+++ b/src/prefabs/Tethers.tsx
@@ -18,6 +18,7 @@ import { type RendererProps, registerRenderer } from '../render/ObjectRegistry';
 import { ForegroundPortal } from '../render/Portals';
 import { LayerName } from '../render/layers';
 import {
+    type Arena,
     type FakeCursorObject,
     ObjectType,
     type Scene,
@@ -85,13 +86,14 @@ const INVALID_END_POS: Vector2d = { x: 20, y: 0 };
 
 function getTargetPoints(
     scene: Scene,
+    arena: Arena,
     startObject: SceneObject | undefined,
     endObject: SceneObject | undefined,
 ): [Vector2d, Vector2d] {
     const startPos = isMoveable(startObject) ? startObject : INVALID_START_POS;
     const endPos = isMoveable(endObject) ? endObject : INVALID_END_POS;
 
-    return [getCanvasCoord(scene, startPos), getCanvasCoord(scene, endPos)];
+    return [getCanvasCoord(scene, arena, startPos), getCanvasCoord(scene, arena, endPos)];
 }
 
 function isGroundObject(object: SceneObject) {
@@ -124,11 +126,12 @@ function getTargetOffset(object: SceneObject | undefined): number {
 
 function getTetherPoints(
     scene: Scene,
+    arena: Arena,
     startObject: SceneObject | undefined,
     endObject: SceneObject | undefined,
     addOffset = 0,
 ): [Vector2d, Vector2d] {
-    const [start, end] = getTargetPoints(scene, startObject, endObject);
+    const [start, end] = getTargetPoints(scene, arena, startObject, endObject);
 
     const unit = vecUnit(vecSub(end, start));
     const dist = distance(start, end);
@@ -149,14 +152,22 @@ function getHighlightProps(object: Tether, baseHighlightProps: ShapeConfig): Nod
 
 interface TetherProps extends RendererProps<Tether> {
     scene: Scene;
+    arena: Arena;
     highlightProps?: ShapeConfig;
     magnetOverrideProps?: ShapeConfig;
     startObject: SceneObject | undefined;
     endObject: SceneObject | undefined;
 }
 
-const LineTetherRenderer: React.FC<TetherProps> = ({ object, scene, highlightProps, startObject, endObject }) => {
-    const [start, end] = getTetherPoints(scene, startObject, endObject);
+const LineTetherRenderer: React.FC<TetherProps> = ({
+    object,
+    scene,
+    arena,
+    highlightProps,
+    startObject,
+    endObject,
+}) => {
+    const [start, end] = getTetherPoints(scene, arena, startObject, endObject);
     const lineProps: LineConfig = {
         points: [start.x, start.y, end.x, end.y],
         fill: object.color,
@@ -179,9 +190,16 @@ const LineTetherRenderer: React.FC<TetherProps> = ({ object, scene, highlightPro
 const POINTER_LENGTH = 10;
 const POINTER_WIDTH = 10;
 
-const CloseTetherRenderer: React.FC<TetherProps> = ({ object, scene, highlightProps, startObject, endObject }) => {
+const CloseTetherRenderer: React.FC<TetherProps> = ({
+    object,
+    scene,
+    arena,
+    highlightProps,
+    startObject,
+    endObject,
+}) => {
     const extent = getArrowStrokeExtent(POINTER_LENGTH, POINTER_WIDTH, object.width);
-    const [start, end] = getTetherPoints(scene, startObject, endObject);
+    const [start, end] = getTetherPoints(scene, arena, startObject, endObject);
     const center = vecMult(vecAdd(start, end), 0.5);
     const offset = vecMult(vecUnit(vecSub(end, start)), extent.top);
 
@@ -223,11 +241,11 @@ const CloseTetherRenderer: React.FC<TetherProps> = ({ object, scene, highlightPr
     );
 };
 
-const FarTetherRenderer: React.FC<TetherProps> = ({ object, scene, highlightProps, startObject, endObject }) => {
+const FarTetherRenderer: React.FC<TetherProps> = ({ object, scene, arena, highlightProps, startObject, endObject }) => {
     // Shrink the tether by the amount that the stroke extends past the tips of the arrows.
     const extent = getArrowStrokeExtent(POINTER_LENGTH, POINTER_WIDTH, object.width);
 
-    const [start, end] = getTetherPoints(scene, startObject, endObject, extent.top);
+    const [start, end] = getTetherPoints(scene, arena, startObject, endObject, extent.top);
 
     const arrowProps: ArrowConfig = {
         points: [start.x, start.y, end.x, end.y],
@@ -265,6 +283,7 @@ interface MagnetTetherProps extends TetherProps {
 const MagnetTetherRenderer: React.FC<MagnetTetherProps> = ({
     object,
     scene,
+    arena,
     highlightProps,
     magnetOverrideProps,
     startObject,
@@ -272,7 +291,7 @@ const MagnetTetherRenderer: React.FC<MagnetTetherProps> = ({
     startType,
     endType,
 }) => {
-    const [start, end] = getTetherPoints(scene, startObject, endObject, object.width);
+    const [start, end] = getTetherPoints(scene, arena, startObject, endObject, object.width);
 
     const lineProps: LineConfig = {
         points: [start.x, start.y, end.x, end.y],
@@ -372,7 +391,7 @@ const TetherRenderer: React.FC<RendererProps<Tether>> = ({ object }) => {
     const overrideProps = useOverrideProps(object);
     const groupRef = React.useRef<Konva.Group>(null);
     const [editMode] = useEditMode();
-    const { scene } = useScene();
+    const { scene, arena } = useScene();
 
     const startObject = getObjectById(scene, object.startId);
     const endObject = getObjectById(scene, object.endId);
@@ -395,6 +414,7 @@ const TetherRenderer: React.FC<RendererProps<Tether>> = ({ object }) => {
                         <Renderer
                             object={object}
                             scene={scene}
+                            arena={arena}
                             highlightProps={highlightProps}
                             magnetOverrideProps={overrideProps}
                             startObject={startObject}
@@ -417,7 +437,7 @@ export interface TetherToCursorProps {
 
 export const TetherToCursor: React.FC<TetherToCursorProps> = ({ startObject, cursorPos, tether }) => {
     const groupRef = React.useRef<Konva.Group>(null);
-    const { scene } = useScene();
+    const { scene, arena } = useScene();
 
     const fakeTetherObject: Tether = {
         id: -1,
@@ -444,6 +464,7 @@ export const TetherToCursor: React.FC<TetherToCursorProps> = ({ startObject, cur
                 <Renderer
                     object={fakeTetherObject}
                     scene={scene}
+                    arena={arena}
                     startObject={startObject}
                     endObject={fakeCursorObject}
                 />

--- a/src/prefabs/zone/ZoneStack.tsx
+++ b/src/prefabs/zone/ZoneStack.tsx
@@ -114,8 +114,8 @@ interface StackOrbsProps extends StackRendererProps {
 }
 
 const StackOrbs: React.FC<StackOrbsProps> = ({ object, radius, ring }) => {
-    const { scene } = useScene();
-    const center = getCanvasCoord(scene, object);
+    const { scene, arena } = useScene();
+    const center = getCanvasCoord(scene, arena, object);
 
     const orbRadius = Math.min(radius * 0.25, 40);
     const orbs = getStackCircleProps(orbRadius, object.count);

--- a/src/render/ArenaRenderer.tsx
+++ b/src/render/ArenaRenderer.tsx
@@ -16,6 +16,7 @@ import {
     useCanvasArenaRect,
 } from '../coord';
 import {
+    type Arena,
     ArenaShape,
     type CustomRadialGrid,
     type CustomRectangularGrid,
@@ -58,17 +59,17 @@ interface BackdropProps {
 }
 
 const Backdrop: React.FC<BackdropProps> = ({ color }) => {
-    const { scene } = useScene();
-    const size = getCanvasSize(scene);
+    const { arena } = useScene();
+    const size = getCanvasSize(arena);
 
     return <Rect fill={color} x={0} y={0} {...size} />;
 };
 
-function getArenaClip(scene: Scene): ((context: KonvaContext) => void) | undefined {
-    const rect = getCanvasArenaRect(scene);
-    const center = getCanvasCoord(scene, { x: 0, y: 0 });
+function getArenaClip(scene: Scene, arena: Arena): ((context: KonvaContext) => void) | undefined {
+    const rect = getCanvasArenaRect(scene, arena);
+    const center = getCanvasCoord(scene, arena, { x: 0, y: 0 });
 
-    switch (scene.arena.shape) {
+    switch (arena.shape) {
         case ArenaShape.Circle:
             return (ctx) => {
                 ctx.beginPath();
@@ -91,26 +92,26 @@ function getArenaClip(scene: Scene): ((context: KonvaContext) => void) | undefin
 }
 
 const ArenaClip: React.FC<PropsWithChildren> = ({ children }) => {
-    const { scene } = useScene();
+    const { scene, arena } = useScene();
 
-    const clip = getArenaClip(scene);
+    const clip = getArenaClip(scene, arena);
 
     return <Group clipFunc={clip}>{children}</Group>;
 };
 
 const BackgroundImage: React.FC = () => {
-    const { scene } = useScene();
+    const { scene, arena } = useScene();
 
-    const url = scene.arena.backgroundImage ?? '';
+    const url = arena.backgroundImage ?? '';
     const ext = getUrlFileExtension(url);
 
     if (!url) {
         return null;
     }
 
-    const opacity = (scene.arena.backgroundOpacity ?? 100) / 100;
-    const position = getCanvasArenaRect(scene);
-    const shadow = scene.arena.shape === ArenaShape.None ? SHADOW : {};
+    const opacity = (arena.backgroundOpacity ?? 100) / 100;
+    const position = getCanvasArenaRect(scene, arena);
+    const shadow = arena.shape === ArenaShape.None ? SHADOW : {};
 
     switch (ext) {
         case '.svg':
@@ -147,9 +148,9 @@ const BackgroundImageSvg: React.FC<BackgroundImageProps> = ({ url, ...props }) =
 };
 
 const BackgroundRenderer: React.FC = () => {
-    const { scene } = useScene();
+    const { arena } = useScene();
 
-    switch (scene.arena.shape) {
+    switch (arena.shape) {
         case ArenaShape.Circle:
             return <CircularBackground />;
 
@@ -193,23 +194,23 @@ const RectangularBackground: React.FC = () => {
 };
 
 const GridRenderer: React.FC = () => {
-    const { scene } = useScene();
+    const { arena } = useScene();
 
-    switch (scene.arena.grid.type) {
+    switch (arena.grid.type) {
         case GridType.None:
             return null;
 
         case GridType.Radial:
-            return <RadialGridRenderer grid={scene.arena.grid} />;
+            return <RadialGridRenderer grid={arena.grid} />;
 
         case GridType.Rectangular:
-            return <RectangularGridRenderer grid={scene.arena.grid} />;
+            return <RectangularGridRenderer grid={arena.grid} />;
 
         case GridType.CustomRectangular:
-            return <CustomRectangularGridRenderer grid={scene.arena.grid} />;
+            return <CustomRectangularGridRenderer grid={arena.grid} />;
 
         case GridType.CustomRadial:
-            return <CustomRadialGridRenderer grid={scene.arena.grid} />;
+            return <CustomRadialGridRenderer grid={arena.grid} />;
     }
 };
 
@@ -256,10 +257,10 @@ function getSpokeGridDivs(divs: number, startAngle: number | undefined, radiusX:
 
 const RadialGridRenderer: React.FC<GridProps<RadialGrid>> = ({ grid }) => {
     const theme = useSceneTheme();
-    const { scene } = useScene();
+    const { scene, arena } = useScene();
 
-    const clip = getArenaClip(scene);
-    const position = getCanvasArenaEllipse(scene);
+    const clip = getArenaClip(scene, arena);
+    const position = getCanvasArenaEllipse(scene, arena);
     const shapeConfig = getGridShapeConfig(theme);
 
     const rings = getRingGridDivs(grid.radialDivs, position.radiusX, position.radiusY);
@@ -295,9 +296,9 @@ const RadialGridRenderer: React.FC<GridProps<RadialGrid>> = ({ grid }) => {
 
 const RectangularGridRenderer: React.FC<GridProps<RectangularGrid>> = ({ grid }) => {
     const theme = useSceneTheme();
-    const { scene } = useScene();
+    const { scene, arena } = useScene();
 
-    const position = getCanvasArenaRect(scene);
+    const position = getCanvasArenaRect(scene, arena);
     const shapeConfig = getGridShapeConfig(theme);
 
     const rows = getLinearGridDivs(grid.rows, position.y, position.height);
@@ -329,10 +330,10 @@ const RectangularGridRenderer: React.FC<GridProps<RectangularGrid>> = ({ grid })
 
 const CustomRectangularGridRenderer: React.FC<GridProps<CustomRectangularGrid>> = ({ grid }) => {
     const theme = useSceneTheme();
-    const { scene } = useScene();
+    const { scene, arena } = useScene();
 
-    const clip = getArenaClip(scene);
-    const position = getCanvasArenaRect(scene);
+    const clip = getArenaClip(scene, arena);
+    const position = getCanvasArenaRect(scene, arena);
     const shapeConfig = getGridShapeConfig(theme);
 
     return (
@@ -343,13 +344,13 @@ const CustomRectangularGridRenderer: React.FC<GridProps<CustomRectangularGrid>> 
                 context.beginPath();
 
                 for (const column of grid.columns) {
-                    const x = getCanvasX(scene, column);
+                    const x = getCanvasX(arena, column);
                     context.moveTo(x, position.y);
                     context.lineTo(x, position.y + position.height);
                 }
 
                 for (const row of grid.rows) {
-                    const y = getCanvasY(scene, row);
+                    const y = getCanvasY(arena, row);
                     context.moveTo(position.x, y);
                     context.lineTo(position.x + position.width, y);
                 }
@@ -365,10 +366,10 @@ const CustomRectangularGridRenderer: React.FC<GridProps<CustomRectangularGrid>> 
 
 const CustomRadialGridRenderer: React.FC<GridProps<CustomRadialGrid>> = ({ grid }) => {
     const theme = useSceneTheme();
-    const { scene } = useScene();
+    const { scene, arena } = useScene();
 
-    const clip = getArenaClip(scene);
-    const position = getCanvasArenaEllipse(scene);
+    const clip = getArenaClip(scene, arena);
+    const position = getCanvasArenaEllipse(scene, arena);
     const shapeConfig = getGridShapeConfig(theme);
 
     const spokes = grid.spokes.map((angle) => circlePointAtAngle(degtorad(angle), position.radiusX, position.radiusY));

--- a/src/render/ArenaTickRenderer.tsx
+++ b/src/render/ArenaTickRenderer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Rect } from 'react-konva';
 import { getCanvasArenaEllipse, getCanvasArenaRect } from '../coord';
-import { type RadialTicks, type RectangularTicks, type Scene, type Ticks, TickType } from '../scene';
+import { type Arena, type RadialTicks, type RectangularTicks, type Scene, type Ticks, TickType } from '../scene';
 import { useScene } from '../SceneProvider';
 import { useSceneTheme } from '../theme';
 import { degtorad, getLinearGridDivs } from '../util';
@@ -11,31 +11,32 @@ const MINOR_TICK_SIZE = 5;
 const TICK_MARGIN = 2;
 
 export const ArenaTickRenderer: React.FC = () => {
-    const { scene } = useScene();
+    const { scene, arena } = useScene();
 
-    if (!scene.arena.ticks) {
+    if (!arena.ticks) {
         return null;
     }
 
-    switch (scene.arena.ticks.type) {
+    switch (arena.ticks.type) {
         case TickType.None:
             return null;
 
         case TickType.Rectangular:
-            return <RectangularTickRenderer scene={scene} ticks={scene.arena.ticks} />;
+            return <RectangularTickRenderer scene={scene} arena={arena} ticks={arena.ticks} />;
 
         case TickType.Radial:
-            return <RadialTickRenderer scene={scene} ticks={scene.arena.ticks} />;
+            return <RadialTickRenderer scene={scene} arena={arena} ticks={arena.ticks} />;
     }
 };
 
 interface TickRendererProps<T extends Ticks> {
     scene: Scene;
+    arena: Arena;
     ticks: T;
 }
 
-const RectangularTickRenderer: React.FC<TickRendererProps<RectangularTicks>> = ({ scene, ticks }) => {
-    const rect = getCanvasArenaRect(scene);
+const RectangularTickRenderer: React.FC<TickRendererProps<RectangularTicks>> = ({ scene, arena, ticks }) => {
+    const rect = getCanvasArenaRect(scene, arena);
 
     const minorProps = getRectangularTicks(ticks, rect, MINOR_TICK_SIZE);
     const majorProps = getCornerTicks(rect, MINOR_TICK_SIZE);
@@ -52,8 +53,8 @@ const RectangularTickRenderer: React.FC<TickRendererProps<RectangularTicks>> = (
     );
 };
 
-const RadialTickRenderer: React.FC<TickRendererProps<RadialTicks>> = ({ scene, ticks }) => {
-    const ellipse = getCanvasArenaEllipse(scene);
+const RadialTickRenderer: React.FC<TickRendererProps<RadialTicks>> = ({ scene, arena, ticks }) => {
+    const ellipse = getCanvasArenaEllipse(scene, arena);
 
     const majorAngles = getRadialAngles(ticks.majorCount, ticks.majorStart);
     const minorAngles = getRadialAngles(ticks.minorCount, ticks.minorStart).filter(

--- a/src/render/DrawTarget.tsx
+++ b/src/render/DrawTarget.tsx
@@ -9,7 +9,7 @@ import { getCanvasCoord, getPointerPosition } from '../coord';
 import { useDefaultCursor } from '../cursor';
 import { EditMode } from '../editMode';
 import { DRAW_LINE_PROPS } from '../prefabs/DrawObjectStyles';
-import { type DrawObject, ObjectType, type Scene } from '../scene';
+import { type Arena, type DrawObject, ObjectType, type Scene } from '../scene';
 import { selectNewObjects, selectNone, useSelection } from '../selection';
 import { useDrawConfig } from '../useDrawConfig';
 import { useEditMode } from '../useEditMode';
@@ -23,11 +23,11 @@ export const DrawTarget: React.FC = () => {
     return editMode === EditMode.Draw ? <DrawTargetLayer /> : null;
 };
 
-function convertPoints(scene: Scene, points: readonly Vector2d[]): number[] {
+function convertPoints(scene: Scene, arena: Arena, points: readonly Vector2d[]): number[] {
     const result: number[] = [];
 
     for (const scenePos of points) {
-        const canvasPos = getCanvasCoord(scene, scenePos);
+        const canvasPos = getCanvasCoord(scene, arena, scenePos);
         result.push(canvasPos.x, canvasPos.y);
     }
 
@@ -66,7 +66,7 @@ const DrawTargetLayer: React.FC = () => {
     const [points, setPoints] = useState<Vector2d[]>([]);
     const [isDrawing, setIsDrawing] = useState(false);
     const [config] = useDrawConfig();
-    const { scene, dispatch } = useScene();
+    const { scene, arena, dispatch } = useScene();
     const [, setSelection] = useSelection();
     const [, setDefaultCursor] = useDefaultCursor();
     const stage = useStage();
@@ -86,7 +86,7 @@ const DrawTargetLayer: React.FC = () => {
     const onMouseDown = (e: KonvaEventObject<MouseEvent>) => {
         setSelection(selectNone());
 
-        const pos = getPointerPosition(scene, e.target.getStage());
+        const pos = getPointerPosition(scene, arena, e.target.getStage());
         if (pos) {
             setIsDrawing(true);
             setPoints([pos]);
@@ -98,7 +98,7 @@ const DrawTargetLayer: React.FC = () => {
             return;
         }
 
-        const pos = getPointerPosition(scene, e.target.getStage());
+        const pos = getPointerPosition(scene, arena, e.target.getStage());
         if (pos) {
             setPoints([...points, pos]);
         }
@@ -118,7 +118,7 @@ const DrawTargetLayer: React.FC = () => {
         }
     };
 
-    const linePoints = convertPoints(scene, points);
+    const linePoints = convertPoints(scene, arena, points);
 
     return (
         <>

--- a/src/render/SceneRenderer.tsx
+++ b/src/render/SceneRenderer.tsx
@@ -9,7 +9,7 @@ import { type EditorState, type SceneAction, SceneContext, useCurrentStep, useSc
 import { SelectionContext, type SelectionState, SpotlightContext } from '../SelectionContext';
 import { getCanvasSize, getSceneCoord } from '../coord';
 import { EditMode } from '../editMode';
-import type { Scene } from '../scene';
+import type { Arena, Scene } from '../scene';
 import { selectNewObjects, selectNone, useSelection } from '../selection';
 import type { UndoContext } from '../undo/undoContext';
 import { useEditMode } from '../useEditMode';
@@ -22,9 +22,9 @@ import { TetherEditRenderer } from './TetherEditRenderer';
 import { LayerName } from './layers';
 
 export const SceneRenderer: React.FC = () => {
-    const { scene } = useScene();
+    const { arena } = useScene();
     const [, setSelection] = use(SelectionContext);
-    const size = getCanvasSize(scene);
+    const size = getCanvasSize(arena);
     const [stage, setStage] = useState<Konva.Stage | null>(null);
     const [editMode] = useEditMode();
 
@@ -58,6 +58,7 @@ export const SceneRenderer: React.FC = () => {
 
 export interface ScenePreviewProps extends RefAttributes<Konva.Stage> {
     scene: Scene;
+    arena: Arena;
     stepIndex?: number;
     width?: number;
     height?: number;
@@ -69,13 +70,14 @@ export interface ScenePreviewProps extends RefAttributes<Konva.Stage> {
 export const ScenePreview: React.FC<ScenePreviewProps> = ({
     ref,
     scene,
+    arena,
     stepIndex,
     width,
     height,
     backgroundColor,
     simple,
 }) => {
-    const size = getCanvasSize(scene);
+    const size = getCanvasSize(arena);
     let scale = 1;
     let x = 0;
     let y = 0;
@@ -170,7 +172,7 @@ interface DropTargetProps extends PropsWithChildren {
 }
 
 const DropTarget: React.FC<DropTargetProps> = ({ stage, children }) => {
-    const { scene, dispatch } = useScene();
+    const { scene, arena, dispatch } = useScene();
     const [, setSelection] = useSelection();
     const [dragObject, setDragObject] = usePanelDrag();
 
@@ -192,7 +194,7 @@ const DropTarget: React.FC<DropTargetProps> = ({ stage, children }) => {
         position.x -= dragObject.offset.x;
         position.y -= dragObject.offset.y;
 
-        const action = getDropAction(dragObject, getSceneCoord(scene, position));
+        const action = getDropAction(dragObject, getSceneCoord(scene, arena, position));
         if (action) {
             dispatch(action);
             setSelection(selectNewObjects(scene, 1));

--- a/src/render/TetherEditRenderer.tsx
+++ b/src/render/TetherEditRenderer.tsx
@@ -22,11 +22,14 @@ const TetherEditLayer: React.FC = () => {
     const [, setDefaultCursor] = useDefaultCursor();
     const [tetherConfig] = useTetherConfig();
     const [selection] = useSelection();
-    const { scene, step } = useScene();
+    const { scene, step, arena } = useScene();
     const stage = useStage();
 
     // https://github.com/reactwg/react-compiler/discussions/18
-    const onMouseMove = useCallback(() => setCursor(getPointerPosition(scene, stage)), [setCursor, scene, stage]);
+    const onMouseMove = useCallback(
+        () => setCursor(getPointerPosition(scene, arena, stage)),
+        [setCursor, scene, arena, stage],
+    );
 
     useLayoutEffect(() => {
         if (stage) {

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -485,6 +485,7 @@ export type SceneObjectWithoutId = Omit<SceneObject, 'id'> & { id?: number };
 
 export interface SceneStep {
     readonly objects: readonly SceneObject[];
+    readonly customArena?: Arena;
 }
 
 export interface Scene {


### PR DESCRIPTION
This fixes #74 

I considered renaming `SceneStep.arena` to `sharedArena` to avoid future code accidentally using it unconditionally, but didn't think that was worth the added complexity in upgrade.ts. (#97 could also make such renames easier since the serialized data no longer has the field names)

An approach where the scene could have multiple shared arenas instead of just one, and letting each step pick between them, was considered, but discarded for now since it'd likely clutter more of the UI for a relatively niche edge case (mutating a custom arena used by multiple steps that isn't just a preset anyway) in a relatively niche feature.