### PR TITLE
Add modifier key support to non-rectangle control points

### DIFF
--- a/src/HelpDialog.tsx
+++ b/src/HelpDialog.tsx
@@ -80,16 +80,56 @@ export const HelpDialog: React.FC<HelpDialogProps> = (props) => {
 
                                 <dt>Left click + drag</dt>
                                 <dd>Move/transform object</dd>
-
+                            </dl>
+                            <h3>While dragging control points</h3>
+                            <dl className={classes.hotkeys}>
                                 <dt>
-                                    <HotkeyName keys="shift" suffix="left click + drag" />
+                                    <HotkeyName keys="shift" />
                                 </dt>
                                 <dd>
-                                    Lock/unlock proportions
-                                    <br />
-                                    during transformation
+                                    <span>
+                                        Lock/unlock proportions <br /> during transformation<sup>1</sup>
+                                    </span>
                                 </dd>
+                                <dt>
+                                    <HotkeyName keys="ctrl" />
+                                </dt>
+                                <dd>
+                                    <span>
+                                        Resize symmetrically<sup>1</sup>
+                                    </span>
+                                </dd>
+
+                                <dt>
+                                    <HotkeyName keys="shift" />
+                                </dt>
+                                <dd>
+                                    <span>
+                                        Keep rotation constant<sup>2</sup>
+                                    </span>
+                                </dd>
+                                <dt>
+                                    <HotkeyName keys="ctrl" />
+                                </dt>
+                                <dd>
+                                    <span>
+                                        Keep length/radius constant<sup>2</sup>
+                                    </span>
+                                </dd>
+
+                                <dt>
+                                    <HotkeyName keys="alt" />
+                                </dt>
+                                <dd>Do not snap to specific angles</dd>
                             </dl>
+                            <div>
+                                <sup>1</sup>: for objects that have their origin in the <br />
+                                object center (job icons, rectangle, etc)
+                            </div>
+                            <div>
+                                <sup>2</sup>: for objects that have their origin on an edge <br />
+                                (cone, line AoE, arrow, etc)
+                            </div>
                         </section>
                     </DialogContent>
                 </HotkeyBlockingDialogBody>

--- a/src/prefabs/RadiusObjectContainer.tsx
+++ b/src/prefabs/RadiusObjectContainer.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Circle, Line } from 'react-konva';
 import { useScene } from '../SceneProvider';
-import { getAbsoluteRotation, getBaseFacingRotation, getPointerAngle, snapAngle } from '../coord';
+import { getAbsoluteRotation, getBaseFacingRotation } from '../coord';
 import { getResizeCursor } from '../cursor';
 import { ActivePortal } from '../render/Portals';
 import {
@@ -26,8 +26,7 @@ import {
     type HandleFuncProps,
     HandleStyle,
     ROTATE_HANDLE_OFFSET,
-    ROTATE_SNAP_DIVISION,
-    ROTATE_SNAP_TOLERANCE,
+    getNewRotationFromPointer,
 } from './controlpoints';
 import { useShowResizer } from './highlight';
 
@@ -159,7 +158,7 @@ function getInnerRadius(
 function getRotation(
     scene: Readonly<Scene>,
     object: RadiusObject,
-    { pointerPos, activeHandleId }: HandleFuncProps,
+    { pointerPos, activeHandleId, modifierKeys }: HandleFuncProps,
     { allowRotate }: ControlPointProps,
 ) {
     if (!allowRotate || !isRotateable(object)) {
@@ -167,9 +166,7 @@ function getRotation(
     }
 
     if (pointerPos && activeHandleId === HandleId.Rotate) {
-        const angle = getPointerAngle(pointerPos);
-        const baseRotation = getBaseFacingRotation(scene, object);
-        return snapAngle(angle - baseRotation, ROTATE_SNAP_DIVISION, ROTATE_SNAP_TOLERANCE) + baseRotation;
+        return getNewRotationFromPointer(scene, object, pointerPos, modifierKeys);
     }
 
     return getAbsoluteRotation(scene, object);

--- a/src/prefabs/Resizer.tsx
+++ b/src/prefabs/Resizer.tsx
@@ -1,14 +1,7 @@
 import type { Vector2d } from 'konva/lib/types';
 import React, { useState } from 'react';
 import { Line, Rect } from 'react-konva';
-import {
-    getAbsolutePosition,
-    getAbsoluteRotation,
-    getBaseFacingRotation,
-    getPointerAngle,
-    rotateCoord,
-    snapAngle,
-} from '../coord';
+import { getAbsolutePosition, getAbsoluteRotation, getBaseFacingRotation, rotateCoord } from '../coord';
 import { getResizeCursor } from '../cursor';
 import { ActivePortal } from '../render/Portals';
 import { type ResizeableObject, type Scene, type SceneObject, type UnknownObject } from '../scene';
@@ -20,11 +13,10 @@ import { createControlPointManager, type ControlledObjectStateBase } from './Con
 import {
     CONTROL_POINT_BORDER_COLOR,
     CONTROL_POINT_BORDER_OUTSET,
+    getNewRotationFromPointer,
     HandleStyle,
     ModifierKeyBehavior,
     ROTATE_HANDLE_OFFSET,
-    ROTATE_SNAP_DIVISION,
-    ROTATE_SNAP_TOLERANCE,
     shouldApplyModifier,
     type EventWithModifierKeys,
     type HandleFuncProps,
@@ -85,12 +77,10 @@ interface ResizableObjectState extends ControlledObjectStateBase {
 function getRotation(
     scene: Readonly<Scene>,
     object: ResizeableObject,
-    { pointerPos, activeHandleId }: HandleFuncProps,
+    { pointerPos, activeHandleId, modifierKeys }: HandleFuncProps,
 ) {
     if (pointerPos && activeHandleId === HandleId.Rotate) {
-        const angle = getPointerAngle(pointerPos);
-        const baseRotation = getBaseFacingRotation(scene, object);
-        return snapAngle(angle - baseRotation, ROTATE_SNAP_DIVISION, ROTATE_SNAP_TOLERANCE) + baseRotation;
+        return getNewRotationFromPointer(scene, object, pointerPos, modifierKeys);
     }
 
     return getAbsoluteRotation(scene, object);

--- a/src/prefabs/controlpoints.ts
+++ b/src/prefabs/controlpoints.ts
@@ -1,5 +1,8 @@
 import type { Vector2d } from 'konva/lib/types';
-import type { Enum } from '../util';
+import { getAbsoluteRotation, getBaseFacingRotation, getPointerAngle, snapAngle } from '../coord';
+import type { MoveableObject, RotateableObject, Scene } from '../scene';
+import { clamp, mod360, type Enum } from '../util';
+import { MAX_CONE_ANGLE, MIN_CONE_ANGLE } from './bounds';
 
 export const CONTROL_POINT_BORDER_COLOR = '#00a1ff';
 export const CONTROL_POINT_BORDER_OUTSET = 2;
@@ -47,6 +50,66 @@ export interface HandleFuncProps {
     pointerPos?: Vector2d;
     modifierKeys?: EventWithModifierKeys;
     activeHandleId?: number;
+}
+
+export function shouldSnapAngle(modifierKeys: EventWithModifierKeys | undefined) {
+    return !modifierKeys?.altKey;
+}
+
+/**
+ * Calculates the rotation based on where the mouse pointer currently is, assuming a
+ * rotation-adjusting control point is being dragged AND that control point is at 0 degrees.
+ * @param obj the object whose rotation is being adjusted
+ * @param pointerPos the position of the mouse pointer relative to the object position
+ * @param modifierKeys any active modifier keys
+ */
+export function getNewRotationFromPointer(
+    scene: Scene,
+    obj: RotateableObject & MoveableObject,
+    pointerPos: Vector2d,
+    modifierKeys: EventWithModifierKeys | undefined,
+) {
+    const angle = getPointerAngle(pointerPos);
+    const baseRotation = getBaseFacingRotation(scene, obj);
+    if (shouldSnapAngle(modifierKeys)) {
+        return snapAngle(angle - baseRotation, ROTATE_SNAP_DIVISION, ROTATE_SNAP_TOLERANCE) + baseRotation;
+    } else {
+        return angle;
+    }
+}
+
+export const AngleHandleType = {
+    /** The handle located clockwise from "up". */
+    CLOCKWISE: 1,
+    /** The handle located counterclockwise from "up". */
+    COUNTERCLOCKWISE: -1,
+};
+export type AngleHandleType = Enum<typeof AngleHandleType>;
+
+/**
+ * Calculates the cone/arc angle based on where the mouse pointer currently is, assuming
+ * an angle-adjusting control point is being dragged.
+ * @param obj the object whose angle is being adjusted
+ * @param pointerPos the position of the mouse pointer relative to the object position
+ * @param modifierKeys any active modifier keys
+ * @param handleType which of the two angle handles is being dragged
+ */
+export function getNewConeAngleFromPointer(
+    scene: Scene,
+    obj: RotateableObject & MoveableObject,
+    pointerPos: Vector2d,
+    modifierKeys: EventWithModifierKeys | undefined,
+    handleType: AngleHandleType,
+): number {
+    const objectRotation = getAbsoluteRotation(scene, obj);
+    const pointerAngle = getPointerAngle(pointerPos);
+    // the first 90deg into the other handle's area should keep the angle at its minimum instead
+    // of maximum, so wrap this half-angle in the range [-90, 270].
+    const newHalfAngle = mod360((pointerAngle - objectRotation) * handleType + 90) - 90;
+    const newAngle = shouldSnapAngle(modifierKeys)
+        ? snapAngle(newHalfAngle, ROTATE_SNAP_DIVISION, ROTATE_SNAP_TOLERANCE) * 2
+        : newHalfAngle * 2;
+    return clamp(newAngle, MIN_CONE_ANGLE, MAX_CONE_ANGLE);
 }
 
 export const SQUARE_FILL_COLOR = '#ffffff';

--- a/src/prefabs/lines.tsx
+++ b/src/prefabs/lines.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Circle, Rect } from 'react-konva';
-import { getAbsoluteRotation, getBaseFacingRotation, getPointerAngle, snapAngle } from '../coord';
+import { getAbsoluteRotation, getBaseFacingRotation } from '../coord';
 import { getResizeCursor } from '../cursor';
 import type { RendererProps } from '../render/ObjectRegistry';
 import { ActivePortal } from '../render/Portals';
@@ -11,7 +11,12 @@ import { CENTER_DOT_RADIUS } from '../theme';
 import { clampRotation, mod360, type Enum } from '../util';
 import { distance, getDistanceFromLine, VEC_ZERO, vecAtAngle } from '../vector';
 import { createControlPointManager, type ControlledObjectStateBase } from './ControlPoint';
-import { CONTROL_POINT_BORDER_COLOR, HandleStyle, type HandleFuncProps } from './controlpoints';
+import {
+    CONTROL_POINT_BORDER_COLOR,
+    getNewRotationFromPointer,
+    HandleStyle,
+    type HandleFuncProps,
+} from './controlpoints';
 import { DraggableObject } from './DraggableObject';
 import { useShowResizer } from './highlight';
 
@@ -35,24 +40,27 @@ const HandleId = {
 } as const;
 type HandleId = Enum<typeof HandleId>;
 
-const ROTATE_SNAP_DIVISION = 15;
-const ROTATE_SNAP_TOLERANCE = 2;
-
 const OUTSET = 2;
 
-function getLength(object: LineProps, { pointerPos, activeHandleId }: HandleFuncProps, minLength: number) {
-    if (pointerPos && activeHandleId === HandleId.Length) {
+function getLength(
+    object: LineProps,
+    { pointerPos, activeHandleId, modifierKeys }: HandleFuncProps,
+    minLength: number,
+) {
+    if (pointerPos && activeHandleId === HandleId.Length && !modifierKeys?.ctrlKey) {
         return Math.max(minLength, Math.round(distance(pointerPos) - OUTSET));
     }
 
     return object.length;
 }
 
-function getRotation(scene: Readonly<Scene>, object: LineProps, { pointerPos, activeHandleId }: HandleFuncProps) {
-    if (pointerPos && activeHandleId === HandleId.Length) {
-        const angle = getPointerAngle(pointerPos);
-        const baseRotation = getBaseFacingRotation(scene, object);
-        return snapAngle(angle - baseRotation, ROTATE_SNAP_DIVISION, ROTATE_SNAP_TOLERANCE) + baseRotation;
+function getRotation(
+    scene: Readonly<Scene>,
+    object: LineProps,
+    { pointerPos, activeHandleId, modifierKeys }: HandleFuncProps,
+) {
+    if (pointerPos && activeHandleId === HandleId.Length && !modifierKeys?.shiftKey) {
+        return getNewRotationFromPointer(scene, object, pointerPos, modifierKeys);
     }
 
     return getAbsoluteRotation(scene, object);

--- a/src/prefabs/zone/StarburstContainer.tsx
+++ b/src/prefabs/zone/StarburstContainer.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Circle, Line } from 'react-konva';
 import { useScene } from '../../SceneProvider';
-import { getAbsoluteRotation, getBaseFacingRotation, getPointerAngle, rotateCoord, snapAngle } from '../../coord';
+import { getAbsoluteRotation, getBaseFacingRotation, rotateCoord } from '../../coord';
 import { getResizeCursor } from '../../cursor';
 import { ActivePortal } from '../../render/Portals';
 import type { Scene, StarburstZone, UnknownObject } from '../../scene';
@@ -11,7 +11,12 @@ import { distance } from '../../vector';
 import { createControlPointManager, type ControlledObjectStateBase } from '../ControlPoint';
 import { DraggableObject } from '../DraggableObject';
 import { MIN_RADIUS } from '../bounds';
-import { CONTROL_POINT_BORDER_COLOR, HandleStyle, type HandleFuncProps } from '../controlpoints';
+import {
+    CONTROL_POINT_BORDER_COLOR,
+    getNewRotationFromPointer,
+    HandleStyle,
+    type HandleFuncProps,
+} from '../controlpoints';
 import { useShowResizer } from '../highlight';
 
 interface StarburstControlProps {
@@ -102,9 +107,6 @@ type HandleId = Enum<typeof HandleId>;
 const OUTSET = 2;
 const ROTATE_HANDLE_OFFSET = 50;
 
-const ROTATE_SNAP_DIVISION = 15;
-const ROTATE_SNAP_TOLERANCE = 2;
-
 function getRadius(object: StarburstZone, { pointerPos, activeHandleId }: HandleFuncProps) {
     if (pointerPos && activeHandleId === HandleId.Radius) {
         return Math.max(MIN_RADIUS, Math.round(distance(pointerPos) - OUTSET));
@@ -127,11 +129,13 @@ function getSpokeWidth(
     return object.spokeWidth;
 }
 
-function getRotation(scene: Readonly<Scene>, object: StarburstZone, { pointerPos, activeHandleId }: HandleFuncProps) {
+function getRotation(
+    scene: Readonly<Scene>,
+    object: StarburstZone,
+    { pointerPos, activeHandleId, modifierKeys }: HandleFuncProps,
+) {
     if (pointerPos && activeHandleId === HandleId.Rotate) {
-        const angle = getPointerAngle(pointerPos);
-        const baseRotation = getBaseFacingRotation(scene, object);
-        return snapAngle(angle - baseRotation, ROTATE_SNAP_DIVISION, ROTATE_SNAP_TOLERANCE) + baseRotation;
+        return getNewRotationFromPointer(scene, object, pointerPos, modifierKeys);
     }
 
     return getAbsoluteRotation(scene, object);

--- a/src/prefabs/zone/ZoneArc.tsx
+++ b/src/prefabs/zone/ZoneArc.tsx
@@ -4,7 +4,7 @@ import { Arc, Circle, Group, Shape } from 'react-konva';
 import { getDragOffset, registerDropHandler } from '../../DropHandler';
 import { useScene } from '../../SceneProvider';
 import Icon from '../../assets/zone/arc.svg?react';
-import { getAbsoluteRotation, getBaseFacingRotation, getPointerAngle, snapAngle } from '../../coord';
+import { getAbsoluteRotation, getBaseFacingRotation } from '../../coord';
 import { getResizeCursor } from '../../cursor';
 import { DetailsItem } from '../../panel/DetailsItem';
 import { type ListComponentProps, registerListComponent } from '../../panel/ListComponentRegistry';
@@ -14,14 +14,21 @@ import { LayerName } from '../../render/layers';
 import { type ArcZone, ObjectType, type Scene } from '../../scene';
 import { useIsDragging } from '../../selection';
 import { CENTER_DOT_RADIUS, DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
-import { type Enum, clamp, clampRotation, degtorad, mod360 } from '../../util';
+import { type Enum, clampRotation, degtorad, mod360 } from '../../util';
 import { VEC_ZERO, distance, getIntersectionDistance, vecAtAngle, vecNormal } from '../../vector';
 import { type ControlledObjectStateBase, createControlPointManager } from '../ControlPoint';
 import { DraggableObject } from '../DraggableObject';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
-import { MAX_CONE_ANGLE, MIN_CONE_ANGLE, MIN_RADIUS } from '../bounds';
-import { CONTROL_POINT_BORDER_COLOR, type HandleFuncProps, HandleStyle } from '../controlpoints';
+import { MIN_RADIUS } from '../bounds';
+import {
+    AngleHandleType,
+    CONTROL_POINT_BORDER_COLOR,
+    type HandleFuncProps,
+    HandleStyle,
+    getNewConeAngleFromPointer,
+    getNewRotationFromPointer,
+} from '../controlpoints';
 import { useHighlightProps, useOverrideProps, useShowResizer } from '../highlight';
 import { getZoneStyle } from './style';
 
@@ -246,11 +253,8 @@ interface ArcState extends ControlledObjectStateBase {
 
 const OUTSET = 2;
 
-const ROTATE_SNAP_DIVISION = 15;
-const ROTATE_SNAP_TOLERANCE = 2;
-
-function getRadius(object: ArcZone, { pointerPos, activeHandleId }: HandleFuncProps) {
-    if (pointerPos && activeHandleId === HandleId.Radius) {
+function getRadius(object: ArcZone, { pointerPos, activeHandleId, modifierKeys }: HandleFuncProps) {
+    if (pointerPos && activeHandleId === HandleId.Radius && !modifierKeys?.ctrlKey) {
         return Math.max(MIN_RADIUS, Math.round(distance(pointerPos) - OUTSET));
     }
 
@@ -272,37 +276,35 @@ function getInnerRadius(scene: Readonly<Scene>, object: ArcZone, { pointerPos, a
     return object.innerRadius;
 }
 
-function getRotation(scene: Readonly<Scene>, object: ArcZone, { pointerPos, activeHandleId }: HandleFuncProps) {
-    if (pointerPos && activeHandleId === HandleId.Radius) {
-        const angle = getPointerAngle(pointerPos);
-        const baseRotation = getBaseFacingRotation(scene, object);
-        return snapAngle(angle - baseRotation, ROTATE_SNAP_DIVISION, ROTATE_SNAP_TOLERANCE) + baseRotation;
+function getRotation(
+    scene: Readonly<Scene>,
+    object: ArcZone,
+    { pointerPos, activeHandleId, modifierKeys }: HandleFuncProps,
+) {
+    if (pointerPos && activeHandleId === HandleId.Radius && !modifierKeys?.shiftKey) {
+        return getNewRotationFromPointer(scene, object, pointerPos, modifierKeys);
     }
 
     return getAbsoluteRotation(scene, object);
 }
 
-function getConeAngle(scene: Readonly<Scene>, object: ArcZone, { pointerPos, activeHandleId }: HandleFuncProps) {
+function getConeAngle(
+    scene: Readonly<Scene>,
+    object: ArcZone,
+    { pointerPos, activeHandleId, modifierKeys }: HandleFuncProps,
+) {
     if (pointerPos) {
-        const objectRotation = getAbsoluteRotation(scene, object);
-        const angle = getPointerAngle(pointerPos);
-
         if (activeHandleId === HandleId.Angle1) {
-            const coneAngle = snapAngle(
-                mod360(angle - objectRotation + 90) - 90,
-                ROTATE_SNAP_DIVISION,
-                ROTATE_SNAP_TOLERANCE,
-            );
-            return clamp(coneAngle * 2, MIN_CONE_ANGLE, MAX_CONE_ANGLE);
+            return getNewConeAngleFromPointer(scene, object, pointerPos, modifierKeys, AngleHandleType.CLOCKWISE);
         }
         if (activeHandleId === HandleId.Angle2) {
-            const coneAngle = snapAngle(
-                mod360(angle - objectRotation + 270) - 270,
-                ROTATE_SNAP_DIVISION,
-                ROTATE_SNAP_TOLERANCE,
+            return getNewConeAngleFromPointer(
+                scene,
+                object,
+                pointerPos,
+                modifierKeys,
+                AngleHandleType.COUNTERCLOCKWISE,
             );
-
-            return clamp(-coneAngle * 2, MIN_CONE_ANGLE, MAX_CONE_ANGLE);
         }
     }
 

--- a/src/prefabs/zone/ZoneCone.tsx
+++ b/src/prefabs/zone/ZoneCone.tsx
@@ -4,7 +4,7 @@ import { Group, Shape, Wedge } from 'react-konva';
 import { getDragOffset, registerDropHandler } from '../../DropHandler';
 import { useScene } from '../../SceneProvider';
 import Icon from '../../assets/zone/cone.svg?react';
-import { getAbsoluteRotation, getBaseFacingRotation, getPointerAngle, snapAngle } from '../../coord';
+import { getAbsoluteRotation, getBaseFacingRotation } from '../../coord';
 import { getResizeCursor } from '../../cursor';
 import { DetailsItem } from '../../panel/DetailsItem';
 import { type ListComponentProps, registerListComponent } from '../../panel/ListComponentRegistry';
@@ -14,14 +14,21 @@ import { LayerName } from '../../render/layers';
 import { type ConeZone, ObjectType, type Scene } from '../../scene';
 import { useIsDragging } from '../../selection';
 import { DEFAULT_AOE_COLOR, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
-import { type Enum, clamp, clampRotation, degtorad, mod360 } from '../../util';
+import { type Enum, clampRotation, degtorad, mod360 } from '../../util';
 import { distance } from '../../vector';
 import { type ControlledObjectStateBase, createControlPointManager } from '../ControlPoint';
 import { DraggableObject } from '../DraggableObject';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
-import { MAX_CONE_ANGLE, MIN_CONE_ANGLE, MIN_RADIUS } from '../bounds';
-import { CONTROL_POINT_BORDER_COLOR, type HandleFuncProps, HandleStyle } from '../controlpoints';
+import { MIN_RADIUS } from '../bounds';
+import {
+    AngleHandleType,
+    CONTROL_POINT_BORDER_COLOR,
+    type HandleFuncProps,
+    HandleStyle,
+    getNewConeAngleFromPointer,
+    getNewRotationFromPointer,
+} from '../controlpoints';
 import { useHighlightProps, useOverrideProps, useShowResizer } from '../highlight';
 import { getZoneStyle } from './style';
 
@@ -212,48 +219,43 @@ interface ConeState extends ControlledObjectStateBase {
 
 const OUTSET = 2;
 
-const ROTATE_SNAP_DIVISION = 15;
-const ROTATE_SNAP_TOLERANCE = 2;
-
-function getRadius(object: ConeZone, { pointerPos, activeHandleId }: HandleFuncProps) {
-    if (pointerPos && activeHandleId === HandleId.Radius) {
+function getRadius(object: ConeZone, { pointerPos, activeHandleId, modifierKeys }: HandleFuncProps) {
+    if (pointerPos && activeHandleId === HandleId.Radius && !modifierKeys?.ctrlKey) {
         return Math.max(MIN_RADIUS, Math.round(distance(pointerPos) - OUTSET));
     }
 
     return object.radius;
 }
 
-function getRotation(scene: Readonly<Scene>, object: ConeZone, { pointerPos, activeHandleId }: HandleFuncProps) {
-    if (pointerPos && activeHandleId === HandleId.Radius) {
-        const angle = getPointerAngle(pointerPos);
-        const baseRotation = getBaseFacingRotation(scene, object);
-        return snapAngle(angle - baseRotation, ROTATE_SNAP_DIVISION, ROTATE_SNAP_TOLERANCE) + baseRotation;
+function getRotation(
+    scene: Readonly<Scene>,
+    object: ConeZone,
+    { pointerPos, activeHandleId, modifierKeys }: HandleFuncProps,
+) {
+    if (pointerPos && activeHandleId === HandleId.Radius && !modifierKeys?.shiftKey) {
+        return getNewRotationFromPointer(scene, object, pointerPos, modifierKeys);
     }
 
     return getAbsoluteRotation(scene, object);
 }
 
-function getConeAngle(scene: Readonly<Scene>, object: ConeZone, { pointerPos, activeHandleId }: HandleFuncProps) {
+function getConeAngle(
+    scene: Readonly<Scene>,
+    object: ConeZone,
+    { pointerPos, activeHandleId, modifierKeys }: HandleFuncProps,
+) {
     if (pointerPos) {
-        const objectRotation = getAbsoluteRotation(scene, object);
-        const angle = getPointerAngle(pointerPos);
-
         if (activeHandleId === HandleId.Angle1) {
-            const coneAngle = snapAngle(
-                mod360(angle - objectRotation + 90) - 90,
-                ROTATE_SNAP_DIVISION,
-                ROTATE_SNAP_TOLERANCE,
-            );
-            return clamp(coneAngle * 2, MIN_CONE_ANGLE, MAX_CONE_ANGLE);
+            return getNewConeAngleFromPointer(scene, object, pointerPos, modifierKeys, AngleHandleType.CLOCKWISE);
         }
         if (activeHandleId === HandleId.Angle2) {
-            const coneAngle = snapAngle(
-                mod360(angle - objectRotation + 270) - 270,
-                ROTATE_SNAP_DIVISION,
-                ROTATE_SNAP_TOLERANCE,
+            return getNewConeAngleFromPointer(
+                scene,
+                object,
+                pointerPos,
+                modifierKeys,
+                AngleHandleType.COUNTERCLOCKWISE,
             );
-
-            return clamp(-coneAngle * 2, MIN_CONE_ANGLE, MAX_CONE_ANGLE);
         }
     }
 


### PR DESCRIPTION
- Shift keeps the rotation fixed, if the control point can do more than rotate the object
  - for rectangle corners, Shift keeps the aspect ratio fixed, using he opposite corner as origin. This makes it feel similar to how the other objects scale from their origin with this modifier.
- Ctrl keeps the radius/length fixed, if the control point can do more than resize the object
  - for rectangle regions, Ctrl moves the origin to the center of the shape and applies the transformation bi-symmetrically. It's not that similar to the new usage for custom control points, but it's a better match than Alt
- Alt ignores the snap angles
  - this is also applied to the angles of cone and arc objects, instead of only their rotation

(Inkscape effectively uses shift to rotate arc objects by having it move both endpoints of the arc around the origin instead of only the one you're dragging. I don't think that's worth emulating here, given the rectangle resizer behavior and the difference in conceptual representation of the arc between this and inkscape)

This addresses most of #52 . IMO setting custom snap angles per arena is not worth the UI clutter. If other specific angles are needed, the angle value can be set directly on the object(s).