### PR TITLE
Fully capture key presses while dragging control points

### DIFF
--- a/src/prefabs/ControlPoint.tsx
+++ b/src/prefabs/ControlPoint.tsx
@@ -158,6 +158,8 @@ export function createControlPointManager<T extends Vector2d, S extends Controll
             };
 
             const handleUpdatedModifier = (e: KeyboardEvent) => {
+                // Prevent browser UI triggering while dragging control points, especially Alt.
+                e.preventDefault();
                 setTransform({ ...transform, modifierKeys: e });
             };
 


### PR DESCRIPTION
This wasn't an issue with Ctrl and Shift, but letting Alt presses (added in #99) propagate to the browser triggers native ui that prevents future Alt presses from being captured by the control point handler.

Fixes #106 