### PR TITLE
Add support for enemy icons, plus a minor enemy ring style update

### DIFF
--- a/src/connections.ts
+++ b/src/connections.ts
@@ -4,6 +4,8 @@ import { ConnectionType } from './EditModeContext';
 import { LayerName } from './render/layers';
 import { getLayerName } from './render/ObjectRegistry';
 import {
+    EnemyIconStyle,
+    isEnemy,
     isIcon,
     isMoveable,
     isRadiusObject,
@@ -11,6 +13,7 @@ import {
     isRotateable,
     type MoveableObject,
     ObjectType,
+    type RadiusObject,
     type Scene,
     type SceneObject,
     type SceneStep,
@@ -422,7 +425,7 @@ function getAttachTopPoint(scene: Scene, objectToAttach: SceneObject, parent: Sc
     if (isResizable(parent)) {
         parentAttachmentPoint = { x: 0, y: parent.height / 2 + addedHeight };
     } else if (isRadiusObject(parent)) {
-        parentAttachmentPoint = { x: 0, y: parent.radius + addedHeight };
+        parentAttachmentPoint = { x: 0, y: getParentRadius(parent) + addedHeight };
     }
     return {
         x: parentAttachmentPoint.x - objectAttatchmentPoint.x,
@@ -465,7 +468,7 @@ function getAttachBottomRightPoint(scene: Scene, objectToAttach: SceneObject, pa
         };
     } else if (isRadiusObject(parent)) {
         const overlap = 0.4;
-        const offset = Math.sqrt((parent.radius * (1 - overlap)) ** 2 / 2);
+        const offset = Math.sqrt((getParentRadius(parent) * (1 - overlap)) ** 2 / 2);
         parentAttachmentPoint = { x: offset + addedOffset, y: -offset };
     }
 
@@ -473,4 +476,15 @@ function getAttachBottomRightPoint(scene: Scene, objectToAttach: SceneObject, pa
         x: parentAttachmentPoint.x - objectAttatchmentPoint.x,
         y: parentAttachmentPoint.y - objectAttatchmentPoint.y,
     };
+}
+
+function getParentRadius(object: RadiusObject & UnknownObject): number {
+    // If the enemy object has an icon, approximately attach things to the icon
+    // instead of the ring. (the icon is technically a square, but since the
+    // non-transparent part is more akin to a circle it's OK to just take half
+    // the icon width as radius even for bottom-right attachments)
+    if (isEnemy(object) && object.icon !== EnemyIconStyle.NoIcon) {
+        return object.radius / 2;
+    }
+    return object.radius;
 }

--- a/src/file/upgrade.ts
+++ b/src/file/upgrade.ts
@@ -3,6 +3,7 @@ import { getAbsoluteRotation, getBaseFacingRotation, rotateCoord } from '../coor
 import {
     type ArrowObject,
     type DrawObject,
+    EnemyIconStyle,
     type EnemyObject,
     EnemyRingStyle,
     type ExaflareZone,
@@ -104,11 +105,13 @@ function upgradeObject(scene: Scene, object: SceneObject): SceneObject {
 // EnemyObject was changed from { rotation?: number }
 // to { rotation: number, omniDirection: boolean, opacity: number }, then
 // to { rotation: number, ring: EnemyRingStyle, opacity: number }
-type LegacyEnemyObject = Omit<EnemyObject, 'opacity' | 'rotation' | 'ring'> & {
+// The `icon: string` property (not configurable after creation) was also replaced with `icon: Enum`.
+type LegacyEnemyObject = Omit<EnemyObject, 'opacity' | 'rotation' | 'ring' | 'icon'> & {
     opacity?: number;
     rotation?: number;
     omniDirection?: boolean;
     ring?: EnemyRingStyle;
+    icon: string | EnemyIconStyle;
 };
 
 function getRingStyle<T extends LegacyEnemyObject>(object: T): EnemyRingStyle {
@@ -123,12 +126,27 @@ function getRingStyle<T extends LegacyEnemyObject>(object: T): EnemyRingStyle {
     return EnemyRingStyle.Directional;
 }
 
+function getEnemyIconStyle<T extends LegacyEnemyObject>(object: T): EnemyIconStyle {
+    switch (object.icon) {
+        case EnemyIconStyle.NoIcon:
+        case EnemyIconStyle.Small:
+        case EnemyIconStyle.Medium:
+        case EnemyIconStyle.Large:
+            return object.icon;
+        default:
+            // While we could guess based on the icon url or even radius,
+            // we should not randomly add extra elements to plans.
+            return EnemyIconStyle.NoIcon;
+    }
+}
+
 function upgradeEnemy(object: LegacyEnemyObject): EnemyObject {
     return {
         ...object,
         rotation: object.rotation ?? 0,
         ring: object.ring ?? getRingStyle(object),
         opacity: object.opacity ?? DEFAULT_ENEMY_OPACITY,
+        icon: getEnemyIconStyle(object),
     };
 }
 

--- a/src/panel/PrefabsPanel.tsx
+++ b/src/panel/PrefabsPanel.tsx
@@ -2,7 +2,7 @@ import { Tab, TabList, Text, useArrowNavigationGroup, useFocusableGroup } from '
 import React, { useState } from 'react';
 import { HotkeyName } from '../HotkeyName';
 import { MarkerArrow } from '../prefabs/Arrow';
-import { EnemyCircle, EnemyHuge, EnemyLarge, EnemyMedium, EnemySmall } from '../prefabs/Enemies';
+import { EnemyLarge, EnemyMedium, EnemySmall, EnemyUnremarkable } from '../prefabs/Enemies';
 import { Waymark1, Waymark2, Waymark3, Waymark4, WaymarkA, WaymarkB, WaymarkC, WaymarkD } from '../prefabs/Markers';
 import {
     PartyAny,
@@ -240,11 +240,10 @@ export const PrefabsPanel: React.FC = () => {
 
             <Section header="Enemies">
                 <ObjectGroup>
-                    <EnemyCircle />
+                    <EnemyUnremarkable />
                     <EnemySmall />
                     <EnemyMedium />
                     <EnemyLarge />
-                    <EnemyHuge />
                 </ObjectGroup>
             </Section>
             <Section header="Tethers">

--- a/src/panel/PropertiesPanel.tsx
+++ b/src/panel/PropertiesPanel.tsx
@@ -42,7 +42,7 @@ import { ArrowPointersControl } from './properties/ArrowControls';
 import { DrawObjectBrushControl } from './properties/BrushControl';
 import { ColorControl, ColorSwatchControl } from './properties/ColorControl';
 import { ConeAngleControl } from './properties/ConeControls';
-import { EnemyRingControl } from './properties/EnemyControls';
+import { EnemyControl } from './properties/EnemyControls';
 import { ExaflareLengthControl, ExaflareSpacingControl } from './properties/ExaflareControls';
 import { EyeInvertControl } from './properties/EyeControls';
 import { HideControl } from './properties/HideControl';
@@ -183,8 +183,9 @@ const Controls: React.FC = () => {
             </div>
 
             <ControlCondition objects={objects} test={isRotateable} control={RotationControl} />
+
+            <ControlCondition objects={objects} test={isEnemy} control={EnemyControl} />
             <div className={mergeClasses(classes.row, classes.rightGap)}>
-                <ControlCondition objects={objects} test={isEnemy} control={EnemyRingControl} />
                 <ControlCondition objects={objects} test={isExaflareZone} control={ExaflareSpacingControl} />
                 <ControlCondition objects={objects} test={isStarburstZone} control={StarburstSpokeCountControl} />
 

--- a/src/panel/properties/EnemyControls.tsx
+++ b/src/panel/properties/EnemyControls.tsx
@@ -1,15 +1,18 @@
-import { Field, makeStyles } from '@fluentui/react-components';
+import { Field, Image, makeStyles, mergeClasses, ToggleButton, Tooltip } from '@fluentui/react-components';
 import {
+    ArrowSyncOffRegular,
+    ArrowSyncRegular,
+    bundleIcon,
     ChevronCircleUpFilled,
     ChevronCircleUpRegular,
     CircleFilled,
     CircleRegular,
-    bundleIcon,
 } from '@fluentui/react-icons';
+import { StatusCircleBlockIcon } from '@fluentui/react-icons-mdl2';
 import React from 'react';
 import { Segment, SegmentedGroup } from '../../Segmented';
 import { ThreeQuarterCircleFilled, ThreeQuarterCircleRegular } from '../../icon/ThreeQuarterCircle';
-import { type EnemyObject, EnemyRingStyle } from '../../scene';
+import { EnemyIconStyle, type EnemyObject, EnemyRingStyle, getEnemyIconUrl } from '../../scene';
 import { useControlStyles } from '../../useControlStyles';
 import { useObjectUpdater } from '../../useObjectUpdater';
 import { commonValue } from '../../util';
@@ -24,35 +27,102 @@ const DirectionalIcon: React.FC = () => {
     return <ThreeQuarterCircleIcon className={classes.directional} />;
 };
 
-export const EnemyRingControl: React.FC<PropertiesControlProps<EnemyObject>> = ({ objects }) => {
+export const EnemyControl: React.FC<PropertiesControlProps<EnemyObject>> = ({ objects }) => {
     const classes = useControlStyles();
+    const localClasses = useStyles();
     const update = useObjectUpdater(objects);
 
     const ring = commonValue(objects, (obj) => obj.ring);
+    const icon = commonValue(objects, (obj) => obj.icon);
+    const rotateIcon = commonValue(objects, (obj) => obj.rotateIcon ?? false);
 
     const onDirectionalChanged = (ring: EnemyRingStyle) => update({ props: { ring } });
+    const onIconChanged = (icon: EnemyIconStyle) => update({ props: { icon } });
+    const handleToggleRotateIcon = () =>
+        update(rotateIcon ? { omit: ['rotateIcon'] } : { props: { rotateIcon: true } });
+
+    const rotationTooltip = rotateIcon ? 'The icon will rotate' : 'The icon will stay upright';
+    const rotationIcon = rotateIcon ? <ArrowSyncRegular /> : <ArrowSyncOffRegular />;
+    const allowNoIcon = objects.every((obj) => obj.ring != EnemyRingStyle.NoRing);
+    const allowNoRing = objects.every((obj) => obj.icon != EnemyIconStyle.NoIcon);
 
     return (
-        <Field label="Ring style" className={classes.cell}>
-            <SegmentedGroup
-                name="enemy-ring"
-                value={ring}
-                onChange={(ev, data) => onDirectionalChanged(data.value as EnemyRingStyle)}
-            >
-                <Segment value={EnemyRingStyle.Directional} icon={<DirectionalIcon />} title="Directional" />
-                <Segment
-                    value={EnemyRingStyle.Omnidirectional}
-                    icon={<ChevronCircleUpIcon />}
-                    title="Omnidirectional"
-                />
-                <Segment value={EnemyRingStyle.NoDirection} icon={<CircleIcon />} title="No direction" />
-            </SegmentedGroup>
-        </Field>
+        <>
+            <div className={mergeClasses(classes.row, classes.rightGap)}>
+                <Field label="Ring style" className={classes.cell}>
+                    <SegmentedGroup
+                        name="enemy-ring"
+                        value={ring}
+                        onChange={(ev, data) => onDirectionalChanged(data.value as EnemyRingStyle)}
+                    >
+                        <Segment value={EnemyRingStyle.Directional} icon={<DirectionalIcon />} title="Directional" />
+                        <Segment
+                            value={EnemyRingStyle.Omnidirectional}
+                            icon={<ChevronCircleUpIcon />}
+                            title="Omnidirectional"
+                        />
+                        <Segment value={EnemyRingStyle.NoDirection} icon={<CircleIcon />} title="No direction" />
+                        {allowNoRing && (
+                            <Segment value={EnemyRingStyle.NoRing} icon={<StatusCircleBlockIcon />} title="No ring" />
+                        )}
+                    </SegmentedGroup>
+                </Field>
+            </div>
+            <div className={mergeClasses(classes.row, classes.rightGap)}>
+                <Field label="Icon style" className={classes.cell}>
+                    <SegmentedGroup
+                        name="enemy-icon"
+                        value={icon}
+                        onChange={(ev, data) => onIconChanged(data.value as EnemyIconStyle)}
+                    >
+                        <Segment
+                            value={EnemyIconStyle.Small}
+                            icon={
+                                <Image
+                                    src={getEnemyIconUrl(EnemyIconStyle.Small)}
+                                    className={localClasses.imageSegment}
+                                />
+                            }
+                        />
+                        <Segment
+                            value={EnemyIconStyle.Medium}
+                            icon={
+                                <Image
+                                    src={getEnemyIconUrl(EnemyIconStyle.Medium)}
+                                    className={localClasses.imageSegment}
+                                />
+                            }
+                        />
+                        <Segment
+                            value={EnemyIconStyle.Large}
+                            icon={
+                                <Image
+                                    src={getEnemyIconUrl(EnemyIconStyle.Large)}
+                                    className={localClasses.imageSegment}
+                                />
+                            }
+                        />
+                        {allowNoIcon && (
+                            <Segment value={EnemyIconStyle.NoIcon} icon={<StatusCircleBlockIcon />} title="No icon" />
+                        )}
+                    </SegmentedGroup>
+                </Field>
+                {icon !== EnemyIconStyle.NoIcon && (
+                    <Tooltip content={rotationTooltip} relationship="label" withArrow>
+                        <ToggleButton checked={!!rotateIcon} onClick={handleToggleRotateIcon} icon={rotationIcon} />
+                    </Tooltip>
+                )}
+            </div>
+        </>
     );
 };
 
 const useStyles = makeStyles({
     directional: {
         transform: 'rotate(135deg)',
+    },
+    imageSegment: {
+        width: '30px',
+        height: '30px',
     },
 });

--- a/src/prefabs/Enemies.tsx
+++ b/src/prefabs/Enemies.tsx
@@ -45,7 +45,7 @@ const INNER_STROKE_RATIO = 1 / 64;
 const SHADOW_BLUR_RATIO = 1 / 10;
 const SHADOW_BLUR_MIN = 2;
 
-function makeIcon(name: string, icon: EnemyIconStyle, radius: number, ring: EnemyRingStyle) {
+function makeIcon(name: string, icon: EnemyIconStyle, radius: number, ring: EnemyRingStyle, rotation?: number) {
     const Component: React.FC = () => {
         return (
             <PrefabIcon
@@ -55,7 +55,7 @@ function makeIcon(name: string, icon: EnemyIconStyle, radius: number, ring: Enem
                     type: ObjectType.Enemy,
                     icon,
                     radius,
-                    rotation: 0,
+                    rotation: rotation ?? 0,
                     ring,
                 }}
             />
@@ -411,4 +411,4 @@ export const EnemyUnremarkable = makeIcon(
 );
 export const EnemySmall = makeIcon('Small enemy', EnemyIconStyle.Small, SIZE_MEDIUM, EnemyRingStyle.Directional);
 export const EnemyMedium = makeIcon('Medium enemy', EnemyIconStyle.Medium, SIZE_LARGE, EnemyRingStyle.Directional);
-export const EnemyLarge = makeIcon('Large enemy', EnemyIconStyle.Large, SIZE_HUGE, EnemyRingStyle.Omnidirectional);
+export const EnemyLarge = makeIcon('Large enemy', EnemyIconStyle.Large, SIZE_HUGE, EnemyRingStyle.Omnidirectional, 180);

--- a/src/prefabs/Enemies.tsx
+++ b/src/prefabs/Enemies.tsx
@@ -3,7 +3,7 @@ import type { ShapeConfig } from 'konva/lib/Shape';
 import type { TextConfig } from 'konva/lib/shapes/Text';
 import * as React from 'react';
 import { type RefObject, useRef } from 'react';
-import { Arc, Circle, Image, Path, Text } from 'react-konva';
+import { Arc, Circle, Group, Image, Line, Path, Text } from 'react-konva';
 import { registerDropHandler } from '../DropHandler';
 import { DetailsItem } from '../panel/DetailsItem';
 import { type ListComponentProps, registerListComponent } from '../panel/ListComponentRegistry';
@@ -39,7 +39,7 @@ const RING_ANGLE = 270;
 const RING_ROTATION = 135;
 const OUTER_STROKE_RATIO = 1 / 32;
 const OUTER_STROKE_MIN = 2;
-const INNER_RADIUS_RATIO = 0.85;
+const INNER_RADIUS_RATIO = 0.8;
 const INNER_STROKE_MIN = 1;
 const INNER_STROKE_RATIO = 1 / 64;
 const SHADOW_BLUR_RATIO = 1 / 10;
@@ -232,6 +232,14 @@ const DirectionalRing: React.FC<DirectionalRingProps> = ({
                     strokeEnabled={false}
                     fill={color}
                 />
+                <SideArrows
+                    innerRadius={innerRadius}
+                    outerRadius={outerRadius}
+                    innerStrokeWidth={innerProps.strokeWidth}
+                    outerStrokeWidth={outerProps.strokeWidth}
+                    color={color}
+                    {...innerProps}
+                />
             </HideGroup>
         </>
     );
@@ -273,7 +281,54 @@ const OmnidirectionalRing: React.FC<DirectionalRingProps> = ({
                     strokeEnabled={false}
                     fill={color}
                 />
+
+                <SideArrows
+                    {...innerProps}
+                    innerRadius={innerRadius}
+                    outerRadius={outerRadius}
+                    innerStrokeWidth={innerProps.strokeWidth}
+                    outerStrokeWidth={outerProps.strokeWidth}
+                    color={color}
+                />
             </HideGroup>
+        </>
+    );
+};
+
+interface SideArrowProps {
+    innerRadius: number;
+    outerRadius: number;
+    outerStrokeWidth: number;
+    innerStrokeWidth: number;
+    color: string;
+}
+
+const SideArrows: React.FC<SideArrowProps> = ({
+    innerRadius,
+    outerRadius,
+    outerStrokeWidth,
+    innerStrokeWidth,
+    color,
+    ...innerProps
+}) => {
+    if (outerRadius < 20) {
+        return null;
+    }
+    const sideArrowDistance = (innerRadius + innerStrokeWidth / 2 + outerRadius - outerStrokeWidth / 2) / 2;
+    const sideArrowWidth = outerRadius - sideArrowDistance - outerStrokeWidth / 2;
+
+    const largerArrowPoints = [-sideArrowWidth, 0, 0, -sideArrowWidth * 1.5, sideArrowWidth, 0];
+    const smallerArrowPoints = [-sideArrowWidth / 2, sideArrowWidth / 2, 0, 0, sideArrowWidth / 2, sideArrowWidth / 2];
+    return (
+        <>
+            <Group offsetX={sideArrowDistance}>
+                <Line {...innerProps} points={largerArrowPoints} fill={color} />
+                <Line {...innerProps} points={smallerArrowPoints} fill={color} />
+            </Group>
+            <Group offsetX={-sideArrowDistance}>
+                <Line {...innerProps} points={largerArrowPoints} fill={color} />
+                <Line {...innerProps} points={smallerArrowPoints} fill={color} />
+            </Group>
         </>
     );
 };

--- a/src/prefabs/Enemies.tsx
+++ b/src/prefabs/Enemies.tsx
@@ -86,8 +86,10 @@ interface RingProps extends ShapeConfig {
     name?: string;
     radius: number;
     color: string;
-    highlightProps?: ShapeConfig;
-    overrideProps?: ShapeConfig;
+
+    // These may be unused for plain-circle rings
+    rotation: number;
+    groupRef: RefObject<Konva.Group | null>;
 }
 
 interface EnemyLabelProps extends TextConfig {
@@ -163,39 +165,21 @@ function getShapeProps(color: string, radius: number, strokeRatio: number, minSt
     };
 }
 
-const CircleRing: React.FC<RingProps> = ({ radius, color, highlightProps, overrideProps, opacity, ...props }) => {
+const CircleRing: React.FC<RingProps> = ({ radius, color, opacity, ...props }) => {
     const outerProps = getShapeProps(color, radius, OUTER_STROKE_RATIO, OUTER_STROKE_MIN);
     const innerProps = getShapeProps(color, radius, INNER_STROKE_RATIO, INNER_STROKE_MIN);
     const innerRadius = getInnerRadius(radius);
     const outerRadius = getOuterRadius(radius, outerProps.strokeWidth);
 
     return (
-        <>
-            {highlightProps && <Circle radius={radius} {...highlightProps} {...overrideProps} />}
-
-            <HideGroup opacity={opacity} {...props}>
-                <Circle {...outerProps} radius={outerRadius} />
-                <Circle {...innerProps} radius={innerRadius} />
-            </HideGroup>
-        </>
+        <HideGroup opacity={opacity} {...props}>
+            <Circle {...outerProps} radius={outerRadius} />
+            <Circle {...innerProps} radius={innerRadius} />
+        </HideGroup>
     );
 };
 
-interface DirectionalRingProps extends RingProps {
-    rotation: number;
-    groupRef: RefObject<Konva.Group | null>;
-}
-
-const DirectionalRing: React.FC<DirectionalRingProps> = ({
-    radius,
-    color,
-    opacity,
-    rotation,
-    highlightProps,
-    overrideProps,
-    groupRef,
-    ...props
-}) => {
+const DirectionalRing: React.FC<RingProps> = ({ radius, color, opacity, rotation, groupRef, ...props }) => {
     const outerProps = getShapeProps(color, radius, OUTER_STROKE_RATIO, OUTER_STROKE_MIN);
     const innerProps = getShapeProps(color, radius, INNER_STROKE_RATIO, INNER_STROKE_MIN);
     const innerRadius = getInnerRadius(radius);
@@ -206,55 +190,42 @@ const DirectionalRing: React.FC<DirectionalRingProps> = ({
     useKonvaCache(groupRef, [radius, color]);
 
     return (
-        <>
-            {highlightProps && <Circle radius={radius} {...highlightProps} {...overrideProps} />}
-
-            <HideGroup opacity={opacity} ref={groupRef} rotation={rotation} {...props}>
-                <Circle radius={radius} fill="transparent" />
-                <Arc
-                    {...outerProps}
-                    rotation={RING_ROTATION}
-                    angle={RING_ANGLE}
-                    innerRadius={outerRadius}
-                    outerRadius={outerRadius}
-                />
-                <Arc
-                    {...innerProps}
-                    rotation={RING_ROTATION}
-                    angle={RING_ANGLE}
-                    innerRadius={innerRadius}
-                    outerRadius={innerRadius}
-                />
-                <Path
-                    data="M0-41c-2 2-4 7-4 10 4 0 4 0 8 0 0-3-2-8-4-10"
-                    scaleX={arrowScale}
-                    scaleY={arrowScale}
-                    strokeEnabled={false}
-                    fill={color}
-                />
-                <SideArrows
-                    innerRadius={innerRadius}
-                    outerRadius={outerRadius}
-                    innerStrokeWidth={innerProps.strokeWidth}
-                    outerStrokeWidth={outerProps.strokeWidth}
-                    color={color}
-                    {...innerProps}
-                />
-            </HideGroup>
-        </>
+        <HideGroup opacity={opacity} ref={groupRef} rotation={rotation} {...props}>
+            <Circle radius={radius} fill="transparent" />
+            <Arc
+                {...outerProps}
+                rotation={RING_ROTATION}
+                angle={RING_ANGLE}
+                innerRadius={outerRadius}
+                outerRadius={outerRadius}
+            />
+            <Arc
+                {...innerProps}
+                rotation={RING_ROTATION}
+                angle={RING_ANGLE}
+                innerRadius={innerRadius}
+                outerRadius={innerRadius}
+            />
+            <Path
+                data="M0-41c-2 2-4 7-4 10 4 0 4 0 8 0 0-3-2-8-4-10"
+                scaleX={arrowScale}
+                scaleY={arrowScale}
+                strokeEnabled={false}
+                fill={color}
+            />
+            <SideArrows
+                innerRadius={innerRadius}
+                outerRadius={outerRadius}
+                innerStrokeWidth={innerProps.strokeWidth}
+                outerStrokeWidth={outerProps.strokeWidth}
+                color={color}
+                {...innerProps}
+            />
+        </HideGroup>
     );
 };
 
-const OmnidirectionalRing: React.FC<DirectionalRingProps> = ({
-    radius,
-    color,
-    opacity,
-    rotation,
-    highlightProps,
-    overrideProps,
-    groupRef,
-    ...props
-}) => {
+const OmnidirectionalRing: React.FC<RingProps> = ({ radius, color, opacity, rotation, groupRef, ...props }) => {
     const outerProps = getShapeProps(color, radius, OUTER_STROKE_RATIO, OUTER_STROKE_MIN);
     const innerProps = getShapeProps(color, radius, INNER_STROKE_RATIO, INNER_STROKE_MIN);
     const innerRadius = getInnerRadius(radius);
@@ -265,33 +236,29 @@ const OmnidirectionalRing: React.FC<DirectionalRingProps> = ({
     useKonvaCache(groupRef, [radius, color]);
 
     return (
-        <>
-            {highlightProps && <Circle radius={radius} {...highlightProps} {...overrideProps} />}
+        <HideGroup opacity={opacity} ref={groupRef} rotation={rotation} {...props}>
+            <Circle radius={radius} fill="transparent" />
 
-            <HideGroup opacity={opacity} ref={groupRef} rotation={rotation} {...props}>
-                <Circle radius={radius} fill="transparent" />
+            <Circle {...outerProps} radius={outerRadius} />
+            <Circle {...innerProps} radius={innerRadius} />
 
-                <Circle {...outerProps} radius={outerRadius} />
-                <Circle {...innerProps} radius={innerRadius} />
+            <Path
+                data="M0-40c-2 2-4 7-4 10l4-2L4-30c0-3-2-8-4-10"
+                scaleX={arrowScale}
+                scaleY={arrowScale}
+                strokeEnabled={false}
+                fill={color}
+            />
 
-                <Path
-                    data="M0-40c-2 2-4 7-4 10l4-2L4-30c0-3-2-8-4-10"
-                    scaleX={arrowScale}
-                    scaleY={arrowScale}
-                    strokeEnabled={false}
-                    fill={color}
-                />
-
-                <SideArrows
-                    {...innerProps}
-                    innerRadius={innerRadius}
-                    outerRadius={outerRadius}
-                    innerStrokeWidth={innerProps.strokeWidth}
-                    outerStrokeWidth={outerProps.strokeWidth}
-                    color={color}
-                />
-            </HideGroup>
-        </>
+            <SideArrows
+                {...innerProps}
+                innerRadius={innerRadius}
+                outerRadius={outerRadius}
+                innerStrokeWidth={innerProps.strokeWidth}
+                outerStrokeWidth={outerProps.strokeWidth}
+                color={color}
+            />
+        </HideGroup>
     );
 };
 
@@ -348,36 +315,23 @@ function renderRing(
     highlightProps?: ShapeConfig,
     overrideProps?: ShapeConfig,
 ) {
+    let RingType: React.FC<RingProps> | undefined;
     switch (object.ring) {
         case EnemyRingStyle.NoDirection:
-            return (
-                <CircleRing
-                    radius={radius}
-                    color={object.color}
-                    opacity={object.opacity / 100}
-                    highlightProps={highlightProps}
-                    overrideProps={overrideProps}
-                    {...overrideProps}
-                />
-            );
-
+            RingType = CircleRing;
+            break;
         case EnemyRingStyle.Directional:
-            return (
-                <DirectionalRing
-                    radius={radius}
-                    rotation={rotation}
-                    color={object.color}
-                    opacity={object.opacity / 100}
-                    highlightProps={highlightProps}
-                    overrideProps={overrideProps}
-                    groupRef={groupRef}
-                    {...overrideProps}
-                />
-            );
-
+            RingType = DirectionalRing;
+            break;
         case EnemyRingStyle.Omnidirectional:
-            return (
-                <OmnidirectionalRing
+            RingType = OmnidirectionalRing;
+            break;
+    }
+
+    return (
+        <>
+            {RingType && (
+                <RingType
                     radius={radius}
                     rotation={rotation}
                     color={object.color}
@@ -387,10 +341,10 @@ function renderRing(
                     groupRef={groupRef}
                     {...overrideProps}
                 />
-            );
-        case EnemyRingStyle.NoRing:
-            return null;
-    }
+            )}
+            {highlightProps && <Circle radius={radius} {...highlightProps} {...overrideProps} />}
+        </>
+    );
 }
 
 const EnemyRenderer: React.FC<EnemyRendererProps> = ({ object, radius, rotation, groupRef, isDragging }) => {
@@ -408,7 +362,7 @@ const EnemyRenderer: React.FC<EnemyRendererProps> = ({ object, radius, rotation,
             </HideGroup>
 
             {object.icon !== EnemyIconStyle.NoIcon && (
-                <HideGroup opacity={object.opacity / 100}>
+                <HideGroup opacity={object.opacity / 100} {...overrideProps}>
                     <EnemyIcon icon={object.icon} radius={radius} rotation={object.rotateIcon ? rotation : 0} />
                 </HideGroup>
             )}

--- a/src/prefabs/Enemies.tsx
+++ b/src/prefabs/Enemies.tsx
@@ -3,13 +3,13 @@ import type { ShapeConfig } from 'konva/lib/Shape';
 import type { TextConfig } from 'konva/lib/shapes/Text';
 import * as React from 'react';
 import { type RefObject, useRef } from 'react';
-import { Arc, Circle, Path, Text } from 'react-konva';
+import { Arc, Circle, Image, Path, Text } from 'react-konva';
 import { registerDropHandler } from '../DropHandler';
 import { DetailsItem } from '../panel/DetailsItem';
 import { type ListComponentProps, registerListComponent } from '../panel/ListComponentRegistry';
 import { registerRenderer, type RendererProps } from '../render/ObjectRegistry';
 import { LayerName } from '../render/layers';
-import { type EnemyObject, EnemyRingStyle, ObjectType } from '../scene';
+import { EnemyIconStyle, type EnemyObject, EnemyRingStyle, getEnemyIconUrl, ObjectType } from '../scene';
 import {
     CENTER_DOT_RADIUS,
     DEFAULT_ENEMY_COLOR,
@@ -18,6 +18,7 @@ import {
     useSceneTheme,
 } from '../theme';
 import { useKonvaCache } from '../useKonvaCache';
+import { useImageTracked } from '../useObjectLoading';
 import { makeDisplayName } from '../util';
 import { HideGroup } from './HideGroup';
 import { PrefabIcon } from './PrefabIcon';
@@ -44,20 +45,18 @@ const INNER_STROKE_RATIO = 1 / 64;
 const SHADOW_BLUR_RATIO = 1 / 10;
 const SHADOW_BLUR_MIN = 2;
 
-function makeIcon(name: string, icon: string, radius: number, hasDirection = true) {
+function makeIcon(name: string, icon: EnemyIconStyle, radius: number, ring: EnemyRingStyle) {
     const Component: React.FC = () => {
-        const iconUrl = `/actor/${icon}`;
-
         return (
             <PrefabIcon
                 name={name}
-                icon={iconUrl}
+                icon={getEnemyIconUrl(icon)}
                 object={{
                     type: ObjectType.Enemy,
-                    icon: iconUrl,
-                    radius: radius,
+                    icon,
+                    radius,
                     rotation: 0,
-                    ring: hasDirection ? EnemyRingStyle.Directional : EnemyRingStyle.NoDirection,
+                    ring,
                 }}
             />
         );
@@ -71,7 +70,7 @@ registerDropHandler<EnemyObject>(ObjectType.Enemy, (object, position) => {
         type: 'add',
         object: {
             type: ObjectType.Enemy,
-            icon: '',
+            icon: EnemyIconStyle.NoIcon,
             name: '',
             color: DEFAULT_ENEMY_COLOR,
             opacity: DEFAULT_ENEMY_OPACITY,
@@ -94,9 +93,10 @@ interface RingProps extends ShapeConfig {
 interface EnemyLabelProps extends TextConfig {
     name?: string;
     radius: number;
+    icon: EnemyIconStyle;
 }
 
-const EnemyLabel: React.FC<EnemyLabelProps> = ({ name, radius, ...props }) => {
+const EnemyLabel: React.FC<EnemyLabelProps> = ({ name, radius, icon, ...props }) => {
     if (radius < 32) {
         return null;
     }
@@ -110,7 +110,7 @@ const EnemyLabel: React.FC<EnemyLabelProps> = ({ name, radius, ...props }) => {
             width={radius * 2}
             height={radius * 2}
             offsetX={radius}
-            offsetY={radius}
+            offsetY={icon === EnemyIconStyle.NoIcon ? radius : radius * 1.5}
             fontSize={fontSize}
             strokeWidth={strokeWidth}
             align="center"
@@ -118,6 +118,26 @@ const EnemyLabel: React.FC<EnemyLabelProps> = ({ name, radius, ...props }) => {
             fillAfterStrokeEnabled
             listening={false}
             {...props}
+        />
+    );
+};
+
+interface EnemyIconProps {
+    icon: EnemyIconStyle;
+    radius: number;
+    rotation: number;
+}
+
+const EnemyIcon: React.FC<EnemyIconProps> = ({ icon, radius, rotation }) => {
+    const [image] = useImageTracked(getEnemyIconUrl(icon));
+    return (
+        <Image
+            image={image}
+            width={radius}
+            height={radius}
+            rotation={rotation}
+            offsetX={radius / 2}
+            offsetY={radius / 2}
         />
     );
 };
@@ -313,6 +333,8 @@ function renderRing(
                     {...overrideProps}
                 />
             );
+        case EnemyRingStyle.NoRing:
+            return null;
     }
 }
 
@@ -327,9 +349,14 @@ const EnemyRenderer: React.FC<EnemyRendererProps> = ({ object, radius, rotation,
             <HideGroup {...overrideProps}>
                 {isDragging && <Circle radius={CENTER_DOT_RADIUS} fill={object.color} />}
 
-                <EnemyLabel name={object.name} radius={radius} color={object.color} {...textConfig} />
+                <EnemyLabel name={object.name} radius={radius} icon={object.icon} {...textConfig} />
             </HideGroup>
 
+            {object.icon !== EnemyIconStyle.NoIcon && (
+                <HideGroup opacity={object.opacity / 100}>
+                    <EnemyIcon icon={object.icon} radius={radius} rotation={object.rotateIcon ? rotation : 0} />
+                </HideGroup>
+            )}
             {renderRing(object, radius, rotation, groupRef, highlightProps, overrideProps)}
         </>
     );
@@ -362,13 +389,17 @@ const EnemyContainer: React.FC<RendererProps<EnemyObject>> = ({ object }) => {
 registerRenderer<EnemyObject>(ObjectType.Enemy, LayerName.Ground, EnemyContainer);
 
 const EnemyDetails: React.FC<ListComponentProps<EnemyObject>> = ({ object, ...props }) => {
-    return <DetailsItem icon={object.icon} name={object.name || 'Enemy'} object={object} {...props} />;
+    return <DetailsItem icon={getEnemyIconUrl(object.icon)} name={object.name || 'Enemy'} object={object} {...props} />;
 };
 
 registerListComponent<EnemyObject>(ObjectType.Enemy, EnemyDetails);
 
-export const EnemyCircle = makeIcon('Enemy circle', 'enemy_circle.png', SIZE_SMALL, false);
-export const EnemySmall = makeIcon('Small enemy', 'enemy_small.png', SIZE_SMALL);
-export const EnemyMedium = makeIcon('Medium enemy', 'enemy_medium.png', SIZE_MEDIUM);
-export const EnemyLarge = makeIcon('Large enemy', 'enemy_large.png', SIZE_LARGE);
-export const EnemyHuge = makeIcon('Huge enemy', 'enemy_huge.png', SIZE_HUGE, false);
+export const EnemyUnremarkable = makeIcon(
+    'Unremarkable enemy',
+    EnemyIconStyle.NoIcon,
+    SIZE_SMALL,
+    EnemyRingStyle.NoDirection,
+);
+export const EnemySmall = makeIcon('Small enemy', EnemyIconStyle.Small, SIZE_MEDIUM, EnemyRingStyle.Directional);
+export const EnemyMedium = makeIcon('Medium enemy', EnemyIconStyle.Medium, SIZE_LARGE, EnemyRingStyle.Directional);
+export const EnemyLarge = makeIcon('Large enemy', EnemyIconStyle.Large, SIZE_HUGE, EnemyRingStyle.Omnidirectional);

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -237,13 +237,37 @@ export const EnemyRingStyle = {
     NoDirection: 'none',
     Directional: 'dir',
     Omnidirectional: 'omni',
+    NoRing: 'empty',
 } as const;
 export type EnemyRingStyle = Enum<typeof EnemyRingStyle>;
 
+export const EnemyIconStyle = {
+    NoIcon: 'none',
+    Small: 'small',
+    Medium: 'medium',
+    Large: 'large',
+} as const;
+export type EnemyIconStyle = Enum<typeof EnemyIconStyle>;
+
+export function getEnemyIconUrl(style: EnemyIconStyle): string {
+    switch (style) {
+        case EnemyIconStyle.NoIcon:
+            return '/actor/enemy_circle.png';
+        case EnemyIconStyle.Small:
+            return '/actor/enemy1.png';
+        case EnemyIconStyle.Medium:
+            return '/actor/enemy2.png';
+        case EnemyIconStyle.Large:
+            return '/actor/enemy3.png';
+    }
+}
+
 export interface EnemyObject extends RadiusObject, RotateableObject, NamedObject, ColoredObject, BaseObject {
     readonly type: typeof ObjectType.Enemy;
-    readonly icon: string;
+    readonly icon: EnemyIconStyle;
     readonly ring: EnemyRingStyle;
+    /** Whether the icon should rotate with the ring, or stay upright. */
+    readonly rotateIcon?: boolean;
 }
 export const isEnemy = makeObjectTest<EnemyObject>(ObjectType.Enemy);
 


### PR DESCRIPTION
To avoid major changes to existing plans, do not automatically guess what icon to use based on any property and just keep the icon absent. (the existing icon could have been random, and was not editable) Move the enemy name to be above the icon if both are present.

Include an option to rotate the icon to match the ring orientation. I can see both being preferred in certain scenarios (and rotation is necessary for eventual stgy support).
Also add an option to turn off the ring completely, now that there's an alternative. Prevent picking no-ring AND no-icon in the properties panel.

(the size was arbitrarily picked to be the configured radius, which feels reasonable when trying it out. If a different size is desired enough, two enemy objects could be stacked on top of each other, one without icon and one without ring)

Standard opacity of 65%, and sharing the opacity with the target ring, seems to work reasonably.
Keeping the icon on the same rendering layer as the ring also seems reasonable. Even though it might look neat if e.g. a
cone emits from under the icon but over the ring, the ring is often the more important part in strategy plans so shouldn't be any less prominent than the icon. And at that point it can just be changed at will via the scene ordering.


Additionally, update the ring styles: shrink the inner ring a little to better match the in-game inner ring, and add side arrows to directional rings to mark enemy flanks.

This fixes #34 , and is a prerequisite for #95 