### PR TITLE
Allow the eye object to be rotated.

### DIFF
--- a/src/file/upgrade.ts
+++ b/src/file/upgrade.ts
@@ -7,6 +7,7 @@ import {
     type EnemyObject,
     EnemyRingStyle,
     type ExaflareZone,
+    type EyeObject,
     type ImageObject,
     type LineZone,
     type MarkerObject,
@@ -28,6 +29,7 @@ import {
     isDrawObject,
     isEnemy,
     isExaflareZone,
+    isEye,
     isImageObject,
     isLineZone,
     isMarker,
@@ -97,6 +99,10 @@ function upgradeObject(scene: Scene, object: SceneObject): SceneObject {
 
     if (isArrow(object)) {
         object = upgradeArrow(scene, object);
+    }
+
+    if (isEye(object)) {
+        object = upgradeEye(object);
     }
 
     return object;
@@ -339,4 +345,16 @@ function convertResizableToLine<T extends ResizeableObject>(
         length,
         rotation: updateRotation(scene, object, offset),
     } as Omit<T, 'height'> & { length: number };
+}
+
+// rotation property was added to EyeObject
+type LegacyEyeObject = Omit<EyeObject, 'rotation'> & {
+    readonly rotation?: number;
+};
+
+function upgradeEye(object: LegacyEyeObject): EyeObject {
+    return {
+        rotation: 0,
+        ...object,
+    };
 }

--- a/src/prefabs/zone/ZoneEye.tsx
+++ b/src/prefabs/zone/ZoneEye.tsx
@@ -41,6 +41,7 @@ registerDropHandler<EyeObject>(ObjectType.Eye, (object, position) => {
             color: DEFAULT_COLOR,
             opacity: DEFAULT_OPACITY,
             radius: DEFAULT_RADIUS,
+            rotation: 0,
             ...object,
             ...position,
         } as EyeObject,
@@ -102,10 +103,11 @@ const INNER_EYE_PATH = 'M20 0Q10-9 0-9T-20 0Q-10 9 0 9T20 0Z';
 
 interface EyeRendererProps extends RendererProps<EyeObject> {
     radius: number;
+    rotation: number;
     groupRef: RefObject<Konva.Group | null>;
 }
 
-const EyeRenderer: React.FC<EyeRendererProps> = ({ object, radius, groupRef }) => {
+const EyeRenderer: React.FC<EyeRendererProps> = ({ object, rotation, radius, groupRef }) => {
     const highlightProps = useHighlightProps(object);
     const overrideProps = useOverrideProps(object);
     const scale = radius / 20;
@@ -128,7 +130,7 @@ const EyeRenderer: React.FC<EyeRendererProps> = ({ object, radius, groupRef }) =
 
     return (
         <>
-            <Group ref={groupRef} {...overrideProps}>
+            <Group rotation={rotation} ref={groupRef} {...overrideProps}>
                 <Group scaleX={scale} scaleY={scale}>
                     {highlightProps && (
                         <Path data={OUTER_EYE_PATH} scaleX={21 / 20} scaleY={22 / 20} {...highlightProps} />
@@ -187,8 +189,10 @@ const EyeContainer: React.FC<RendererProps<EyeObject>> = ({ object }) => {
     const groupRef = useRef<Konva.Group>(null);
 
     return (
-        <RadiusObjectContainer object={object} onTransformEnd={() => groupRef.current?.clearCache()}>
-            {({ radius }) => <EyeRenderer object={object} radius={radius} groupRef={groupRef} />}
+        <RadiusObjectContainer object={object} onTransformEnd={() => groupRef.current?.clearCache()} allowRotate>
+            {({ radius, rotation }) => (
+                <EyeRenderer rotation={rotation} object={object} radius={radius} groupRef={groupRef} />
+            )}
         </RadiusObjectContainer>
     );
 };

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -297,7 +297,7 @@ export interface StackZone extends StackCountObject, RadiusObject, ColoredObject
 }
 export const isStackZone = makeObjectTest<StackZone>(ObjectType.Stack);
 
-export interface EyeObject extends RadiusObject, ColoredObject, HollowObject, BaseObject {
+export interface EyeObject extends RadiusObject, RotateableObject, ColoredObject, HollowObject, BaseObject {
     readonly type: typeof ObjectType.Eye;
     readonly invert?: boolean;
 }


### PR DESCRIPTION
While this is not expected to have many practical purposes for non-meme plans, the in-game strategy boards support rotation of the eye object so this will allow for more-faithful imports.