### PR TITLE
Add support for a floor-targeted proximity AoE

### DIFF
--- a/src/file/upgrade.ts
+++ b/src/file/upgrade.ts
@@ -16,6 +16,7 @@ import {
     type PartyObject,
     type PolygonOrientation,
     type PolygonZone,
+    type ProximityZone,
     type RectangleZone,
     type ResizeableObject,
     type RotateableObject,
@@ -35,6 +36,7 @@ import {
     isMarker,
     isParty,
     isPolygonZone,
+    isProximityZone,
     isStackZone,
     isText,
 } from '../scene';
@@ -103,6 +105,10 @@ function upgradeObject(scene: Scene, object: SceneObject): SceneObject {
 
     if (isEye(object)) {
         object = upgradeEye(object);
+    }
+
+    if (isProximityZone(object)) {
+        object = updateProximityZone(object);
     }
 
     return object;
@@ -353,6 +359,18 @@ type LegacyEyeObject = Omit<EyeObject, 'rotation'> & {
 };
 
 function upgradeEye(object: LegacyEyeObject): EyeObject {
+    return {
+        rotation: 0,
+        ...object,
+    };
+}
+
+// ProximityZone was changed to be rotateable
+type LegacyProximityZone = Omit<ProximityZone, 'rotation'> & {
+    rotation?: number;
+};
+
+function updateProximityZone(object: LegacyProximityZone): ProximityZone {
     return {
         rotation: 0,
         ...object,

--- a/src/panel/PropertiesPanel.tsx
+++ b/src/panel/PropertiesPanel.tsx
@@ -23,6 +23,7 @@ import {
     isNamed,
     isParty,
     isPolygonZone,
+    isProximityZone,
     isRadiusObject,
     isResizable,
     isRotateable,
@@ -56,6 +57,7 @@ import { OpacityControl } from './properties/OpacityControl';
 import { PartyIconControl } from './properties/PartyControls';
 import { PolygonOrientationControl, PolygonSidesControl } from './properties/PolygonControls';
 import { PositionControl } from './properties/PositionControl';
+import { ProximityTypeControl } from './properties/ProximityControls';
 import { InnerRadiusControl, RadiusControl } from './properties/RadiusControl';
 import { RotationControl } from './properties/RotationControl';
 import { SizeControl } from './properties/SizeControl';
@@ -180,6 +182,7 @@ const Controls: React.FC = () => {
                 <ControlCondition objects={objects} test={isInnerRadiusObject} control={InnerRadiusControl} />
                 <ControlCondition objects={objects} test={isExaflareZone} control={ExaflareLengthControl} />
                 <ControlCondition objects={objects} test={isStarburstZone} control={StarburstSpokeWidthControl} />
+                <ControlCondition objects={objects} test={isProximityZone} control={ProximityTypeControl} />
             </div>
 
             <ControlCondition objects={objects} test={isRotateable} control={RotationControl} />

--- a/src/panel/properties/ProximityControls.tsx
+++ b/src/panel/properties/ProximityControls.tsx
@@ -1,0 +1,33 @@
+import { Field } from '@fluentui/react-components';
+import { PersonRegular, TargetRegular } from '@fluentui/react-icons';
+import { ProximityStyle, type ProximityZone } from '../../scene';
+import { Segment, SegmentedGroup } from '../../Segmented';
+import { useControlStyles } from '../../useControlStyles';
+import { useObjectUpdater } from '../../useObjectUpdater';
+import { commonValue } from '../../util';
+import type { PropertiesControlProps } from '../PropertiesControl';
+
+export const ProximityTypeControl: React.FC<PropertiesControlProps<ProximityZone>> = ({ objects }) => {
+    const classes = useControlStyles();
+    const update = useObjectUpdater(objects);
+
+    const proximityStyle = commonValue(objects, (obj) => obj.proximityStyle ?? ProximityStyle.Player);
+
+    const onTypeChanged = (newStyle: ProximityStyle) =>
+        newStyle == ProximityStyle.Player
+            ? update({ omit: ['proximityStyle'] })
+            : update({ props: { proximityStyle: newStyle } });
+
+    return (
+        <Field label="Proximity Type" className={classes.cell}>
+            <SegmentedGroup
+                name="proximity-type"
+                value={proximityStyle}
+                onChange={(ev, data) => onTypeChanged(data.value as ProximityStyle)}
+            >
+                <Segment value={ProximityStyle.Player} icon={<PersonRegular />} title="Player-targeted" />
+                <Segment value={ProximityStyle.Ground} icon={<TargetRegular />} title="Ground-targeted" />
+            </SegmentedGroup>
+        </Field>
+    );
+};

--- a/src/prefabs/zone/ZoneArc.tsx
+++ b/src/prefabs/zone/ZoneArc.tsx
@@ -1,6 +1,5 @@
-import type { ArcConfig } from 'konva/lib/shapes/Arc';
 import React, { useState } from 'react';
-import { Arc, Circle, Group, Shape } from 'react-konva';
+import { Arc, Circle, Group } from 'react-konva';
 import { getDragOffset, registerDropHandler } from '../../DropHandler';
 import { useScene } from '../../SceneProvider';
 import Icon from '../../assets/zone/arc.svg?react';
@@ -30,6 +29,7 @@ import {
     getNewRotationFromPointer,
 } from '../controlpoints';
 import { useHighlightProps, useOverrideProps, useShowResizer } from '../highlight';
+import { OffsetArc } from './shapes';
 import { getZoneStyle } from './style';
 
 const NAME = 'Arc';
@@ -75,55 +75,6 @@ registerDropHandler<ArcZone>(ObjectType.Arc, (object, position) => {
         },
     };
 });
-
-interface OffsetArcProps extends ArcConfig {
-    shapeOffset: number;
-}
-
-const OffsetArc: React.FC<OffsetArcProps> = ({ innerRadius, outerRadius, angle, shapeOffset, ...props }) => {
-    const angleRad = degtorad(angle);
-    const offsetInnerRadius = innerRadius - shapeOffset;
-    const offsetOuterRadius = outerRadius + shapeOffset;
-
-    const innerArcX1 = offsetInnerRadius;
-    const innerArcY1 = 0;
-    const innerArcX2 = offsetInnerRadius * Math.cos(angleRad);
-    const innerArcY2 = offsetInnerRadius * Math.sin(angleRad);
-
-    const innerCornerX1 = innerArcX1;
-    const innerCornerY1 = innerArcY1 - shapeOffset;
-    const innerCornerX2 = innerArcX2 + shapeOffset * Math.cos(angleRad + Math.PI / 2);
-    const innerCornerY2 = innerArcY2 + shapeOffset * Math.sin(angleRad + Math.PI / 2);
-
-    const outerArcX1 = offsetOuterRadius;
-    const outerArcY1 = 0;
-    const outerArcX2 = offsetOuterRadius * Math.cos(angleRad);
-    const outerArcY2 = offsetOuterRadius * Math.sin(angleRad);
-
-    const outerCornerX1 = outerArcX1;
-    const outerCornerY1 = outerArcY1 - shapeOffset;
-    const outerCornerX2 = outerArcX2 + shapeOffset * Math.cos(angleRad + Math.PI / 2);
-    const outerCornerY2 = outerArcY2 + shapeOffset * Math.sin(angleRad + Math.PI / 2);
-
-    return (
-        <Shape
-            {...props}
-            sceneFunc={(ctx, shape) => {
-                ctx.beginPath();
-
-                ctx.arc(0, 0, offsetInnerRadius, 0, angleRad, false);
-                ctx.lineTo(innerCornerX2, innerCornerY2);
-                ctx.lineTo(outerCornerX2, outerCornerY2);
-                ctx.arc(0, 0, offsetOuterRadius, angleRad, 0, true);
-                ctx.lineTo(innerCornerX1, innerCornerY1);
-                ctx.lineTo(outerCornerX1, outerCornerY1);
-
-                ctx.closePath();
-                ctx.fillStrokeShape(shape);
-            }}
-        />
-    );
-};
 
 interface ArcRendererProps extends RendererProps<ArcZone> {
     outerRadius: number;

--- a/src/prefabs/zone/ZoneProximity.tsx
+++ b/src/prefabs/zone/ZoneProximity.tsx
@@ -42,6 +42,7 @@ registerDropHandler<ProximityZone>(ObjectType.Proximity, (object, position) => {
             color: COLOR_BLUE_WHITE,
             opacity: DEFAULT_AOE_OPACITY,
             radius: DEFAULT_RADIUS,
+            rotation: 0,
             ...object,
             ...position,
         } as ProximityZone,
@@ -128,6 +129,7 @@ function getShadowOffset(i: number): ShapeConfig {
 
 interface ProximityRendererProps extends RendererProps<ProximityZone> {
     radius: number;
+    rotation: number;
     isDragging?: boolean;
 }
 
@@ -159,13 +161,13 @@ const ProximityRenderer: React.FC<ProximityRendererProps> = ({ object, radius, .
     );
 };
 
-const PlayerProximityMarker: React.FC<ProximityRendererProps> = ({ object, radius }) => {
+const PlayerProximityMarker: React.FC<ProximityRendererProps> = ({ object, rotation, radius }) => {
     const arrow = getArrowStyle(object.color, object.opacity * 3);
     const shadowColor = getShadowColor(object.color);
 
     const arrowScale = Math.max(1, radius / DEFAULT_RADIUS);
     return (
-        <Group scaleX={arrowScale} scaleY={arrowScale}>
+        <Group rotation={rotation} scaleX={arrowScale} scaleY={arrowScale}>
             {CORNER_ANGLES.map((r, i) => (
                 <Group key={i} rotation={r}>
                     <FlareCorner scaleX={SCALE1} scaleY={SCALE1} {...arrow} />
@@ -187,7 +189,7 @@ const PlayerProximityMarker: React.FC<ProximityRendererProps> = ({ object, radiu
     );
 };
 
-const FloorProximityMarker: React.FC<ProximityRendererProps> = ({ object, radius }) => {
+const FloorProximityMarker: React.FC<ProximityRendererProps> = ({ object, rotation, radius }) => {
     const floorCircleScale = Math.max(0.5, radius / DEFAULT_RADIUS);
     const floorCircleStyle = getZoneStyle(
         object.color,
@@ -202,7 +204,7 @@ const FloorProximityMarker: React.FC<ProximityRendererProps> = ({ object, radius
         false,
     );
     return (
-        <Group scaleX={floorCircleScale} scaleY={floorCircleScale}>
+        <Group rotation={rotation} scaleX={floorCircleScale} scaleY={floorCircleScale}>
             <Circle radius={DEFAULT_FLOOR_PROXIMITY_CIRCLE_RADIUS} {...floorCircleStyle} />
             {CORNER_ANGLES.map((r, i) => (
                 <Group key={i} rotation={r - 30}>
@@ -222,7 +224,7 @@ const FloorProximityMarker: React.FC<ProximityRendererProps> = ({ object, radius
 
 const ProximityContainer: React.FC<RendererProps<ProximityZone>> = ({ object }) => {
     return (
-        <RadiusObjectContainer object={object}>
+        <RadiusObjectContainer object={object} allowRotate>
             {(props) => <ProximityRenderer object={object} {...props} />}
         </RadiusObjectContainer>
     );

--- a/src/prefabs/zone/ZoneProximity.tsx
+++ b/src/prefabs/zone/ZoneProximity.tsx
@@ -8,16 +8,19 @@ import { DetailsItem } from '../../panel/DetailsItem';
 import { type ListComponentProps, registerListComponent } from '../../panel/ListComponentRegistry';
 import { registerRenderer, type RendererProps } from '../../render/ObjectRegistry';
 import { LayerName } from '../../render/layers';
-import { type CircleZone, ObjectType } from '../../scene';
+import { ObjectType, ProximityStyle, type ProximityZone } from '../../scene';
 import { COLOR_BLUE_WHITE, DEFAULT_AOE_OPACITY, panelVars } from '../../theme';
 import { degtorad } from '../../util';
 import { HideGroup } from '../HideGroup';
 import { PrefabIcon } from '../PrefabIcon';
 import { RadiusObjectContainer } from '../RadiusObjectContainer';
 import { useHighlightProps, useOverrideProps } from '../highlight';
-import { getArrowStyle, getShadowColor } from './style';
+import { OffsetArc } from './shapes';
+import { getArrowStyle, getShadowColor, getZoneStyle } from './style';
 
 const DEFAULT_RADIUS = 200;
+// (inner circle radius. outsets arcs add 5)
+const DEFAULT_FLOOR_PROXIMITY_CIRCLE_RADIUS = 25;
 
 export const ZoneProximity: React.FC = () => {
     return (
@@ -31,7 +34,7 @@ export const ZoneProximity: React.FC = () => {
     );
 };
 
-registerDropHandler<CircleZone>(ObjectType.Proximity, (object, position) => {
+registerDropHandler<ProximityZone>(ObjectType.Proximity, (object, position) => {
     return {
         type: 'add',
         object: {
@@ -41,7 +44,7 @@ registerDropHandler<CircleZone>(ObjectType.Proximity, (object, position) => {
             radius: DEFAULT_RADIUS,
             ...object,
             ...position,
-        },
+        } as ProximityZone,
     };
 });
 
@@ -123,12 +126,12 @@ function getShadowOffset(i: number): ShapeConfig {
     }
 }
 
-interface ProximityRendererProps extends RendererProps<CircleZone> {
+interface ProximityRendererProps extends RendererProps<ProximityZone> {
     radius: number;
     isDragging?: boolean;
 }
 
-const ProximityRenderer: React.FC<ProximityRendererProps> = ({ object, radius }) => {
+const ProximityRenderer: React.FC<ProximityRendererProps> = ({ object, radius, ...props }) => {
     const highlightProps = useHighlightProps(object);
     const overrideProps = useOverrideProps(object);
     const gradient: ShapeConfig = {
@@ -136,10 +139,6 @@ const ProximityRenderer: React.FC<ProximityRendererProps> = ({ object, radius })
         fillRadialGradientStartRadius: 0,
         fillRadialGradientEndRadius: radius,
     };
-    const arrow = getArrowStyle(object.color, object.opacity * 3);
-    const shadowColor = getShadowColor(object.color);
-
-    const arrowScale = Math.max(1, radius / DEFAULT_RADIUS);
 
     return (
         <>
@@ -148,31 +147,80 @@ const ProximityRenderer: React.FC<ProximityRendererProps> = ({ object, radius })
             <HideGroup {...overrideProps}>
                 <Circle radius={radius} {...gradient} />
 
-                <Group scaleX={arrowScale} scaleY={arrowScale}>
-                    {CORNER_ANGLES.map((r, i) => (
-                        <Group key={i} rotation={r}>
-                            <FlareCorner scaleX={SCALE1} scaleY={SCALE1} {...arrow} />
-                            <FlareCorner
-                                scaleX={SCALE2}
-                                scaleY={SCALE2}
-                                {...arrow}
-                                shadowColor={shadowColor}
-                                {...getShadowOffset(i)}
-                            />
-                        </Group>
-                    ))}
-                    {ARROW_ANGLES.map((r, i) => (
-                        <Group key={i} rotation={r}>
-                            <FlareArrow offsetY={60} {...arrow} shadowColor={shadowColor} />
-                        </Group>
-                    ))}
-                </Group>
+                {(object.proximityStyle === undefined || object.proximityStyle == ProximityStyle.Player) && (
+                    <PlayerProximityMarker object={object} radius={radius} {...props} />
+                )}
+
+                {object.proximityStyle == ProximityStyle.Ground && (
+                    <FloorProximityMarker object={object} radius={radius} {...props} />
+                )}
             </HideGroup>
         </>
     );
 };
 
-const ProximityContainer: React.FC<RendererProps<CircleZone>> = ({ object }) => {
+const PlayerProximityMarker: React.FC<ProximityRendererProps> = ({ object, radius }) => {
+    const arrow = getArrowStyle(object.color, object.opacity * 3);
+    const shadowColor = getShadowColor(object.color);
+
+    const arrowScale = Math.max(1, radius / DEFAULT_RADIUS);
+    return (
+        <Group scaleX={arrowScale} scaleY={arrowScale}>
+            {CORNER_ANGLES.map((r, i) => (
+                <Group key={i} rotation={r}>
+                    <FlareCorner scaleX={SCALE1} scaleY={SCALE1} {...arrow} />
+                    <FlareCorner
+                        scaleX={SCALE2}
+                        scaleY={SCALE2}
+                        {...arrow}
+                        shadowColor={shadowColor}
+                        {...getShadowOffset(i)}
+                    />
+                </Group>
+            ))}
+            {ARROW_ANGLES.map((r, i) => (
+                <Group key={i} rotation={r}>
+                    <FlareArrow offsetY={60} {...arrow} shadowColor={shadowColor} />
+                </Group>
+            ))}
+        </Group>
+    );
+};
+
+const FloorProximityMarker: React.FC<ProximityRendererProps> = ({ object, radius }) => {
+    const floorCircleScale = Math.max(0.5, radius / DEFAULT_RADIUS);
+    const floorCircleStyle = getZoneStyle(
+        object.color,
+        1.15 * object.opacity,
+        DEFAULT_FLOOR_PROXIMITY_CIRCLE_RADIUS,
+        false,
+    );
+    const floorCircleArcStyle = getZoneStyle(
+        object.color,
+        2.5 * object.opacity,
+        DEFAULT_FLOOR_PROXIMITY_CIRCLE_RADIUS + 5,
+        false,
+    );
+    return (
+        <Group scaleX={floorCircleScale} scaleY={floorCircleScale}>
+            <Circle radius={DEFAULT_FLOOR_PROXIMITY_CIRCLE_RADIUS} {...floorCircleStyle} />
+            {CORNER_ANGLES.map((r, i) => (
+                <Group key={i} rotation={r - 30}>
+                    <OffsetArc
+                        angle={60}
+                        innerRadius={DEFAULT_FLOOR_PROXIMITY_CIRCLE_RADIUS + 2}
+                        outerRadius={DEFAULT_FLOOR_PROXIMITY_CIRCLE_RADIUS + 5}
+                        shapeOffset={0}
+                        {...floorCircleArcStyle}
+                        strokeWidth={0}
+                    />
+                </Group>
+            ))}
+        </Group>
+    );
+};
+
+const ProximityContainer: React.FC<RendererProps<ProximityZone>> = ({ object }) => {
     return (
         <RadiusObjectContainer object={object}>
             {(props) => <ProximityRenderer object={object} {...props} />}
@@ -180,9 +228,9 @@ const ProximityContainer: React.FC<RendererProps<CircleZone>> = ({ object }) => 
     );
 };
 
-registerRenderer<CircleZone>(ObjectType.Proximity, LayerName.Ground, ProximityContainer);
+registerRenderer<ProximityZone>(ObjectType.Proximity, LayerName.Ground, ProximityContainer);
 
-const ProximityDetails: React.FC<ListComponentProps<CircleZone>> = ({ object, ...props }) => {
+const ProximityDetails: React.FC<ListComponentProps<ProximityZone>> = ({ object, ...props }) => {
     return (
         <DetailsItem
             icon={<Icon width="100%" height="100%" style={{ [panelVars.colorZoneOrange]: object.color }} />}
@@ -193,4 +241,4 @@ const ProximityDetails: React.FC<ListComponentProps<CircleZone>> = ({ object, ..
     );
 };
 
-registerListComponent<CircleZone>(ObjectType.Proximity, ProximityDetails);
+registerListComponent<ProximityZone>(ObjectType.Proximity, ProximityDetails);

--- a/src/prefabs/zone/shapes.tsx
+++ b/src/prefabs/zone/shapes.tsx
@@ -1,6 +1,7 @@
 import type { ShapeConfig } from 'konva/lib/Shape';
+import type { ArcConfig } from 'konva/lib/shapes/Arc';
 import React from 'react';
-import { Group, Line } from 'react-konva';
+import { Group, Line, Shape } from 'react-konva';
 import { degtorad } from '../../util';
 
 export interface ChevronConfig extends ShapeConfig {
@@ -42,5 +43,54 @@ export const ChevronTail: React.FC<ChevronConfig> = (props) => {
                 strokeEnabled={false}
             />
         </Group>
+    );
+};
+
+export interface OffsetArcProps extends ArcConfig {
+    shapeOffset: number;
+}
+
+export const OffsetArc: React.FC<OffsetArcProps> = ({ innerRadius, outerRadius, angle, shapeOffset, ...props }) => {
+    const angleRad = degtorad(angle);
+    const offsetInnerRadius = innerRadius - shapeOffset;
+    const offsetOuterRadius = outerRadius + shapeOffset;
+
+    const innerArcX1 = offsetInnerRadius;
+    const innerArcY1 = 0;
+    const innerArcX2 = offsetInnerRadius * Math.cos(angleRad);
+    const innerArcY2 = offsetInnerRadius * Math.sin(angleRad);
+
+    const innerCornerX1 = innerArcX1;
+    const innerCornerY1 = innerArcY1 - shapeOffset;
+    const innerCornerX2 = innerArcX2 + shapeOffset * Math.cos(angleRad + Math.PI / 2);
+    const innerCornerY2 = innerArcY2 + shapeOffset * Math.sin(angleRad + Math.PI / 2);
+
+    const outerArcX1 = offsetOuterRadius;
+    const outerArcY1 = 0;
+    const outerArcX2 = offsetOuterRadius * Math.cos(angleRad);
+    const outerArcY2 = offsetOuterRadius * Math.sin(angleRad);
+
+    const outerCornerX1 = outerArcX1;
+    const outerCornerY1 = outerArcY1 - shapeOffset;
+    const outerCornerX2 = outerArcX2 + shapeOffset * Math.cos(angleRad + Math.PI / 2);
+    const outerCornerY2 = outerArcY2 + shapeOffset * Math.sin(angleRad + Math.PI / 2);
+
+    return (
+        <Shape
+            {...props}
+            sceneFunc={(ctx, shape) => {
+                ctx.beginPath();
+
+                ctx.arc(0, 0, offsetInnerRadius, 0, angleRad, false);
+                ctx.lineTo(innerCornerX2, innerCornerY2);
+                ctx.lineTo(outerCornerX2, outerCornerY2);
+                ctx.arc(0, 0, offsetOuterRadius, angleRad, 0, true);
+                ctx.lineTo(innerCornerX1, innerCornerY1);
+                ctx.lineTo(outerCornerX1, outerCornerY1);
+
+                ctx.closePath();
+                ctx.fillStrokeShape(shape);
+            }}
+        />
     );
 };

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -279,18 +279,29 @@ export function isActor(object: UnknownObject): object is Actor {
 export interface CircleZone extends RadiusObject, ColoredObject, HollowObject, BaseObject {
     readonly type:
         | typeof ObjectType.Circle
-        | typeof ObjectType.Proximity
         | typeof ObjectType.Knockback
         | typeof ObjectType.RotateCW
         | typeof ObjectType.RotateCCW;
 }
 export const isCircleZone = makeObjectTest<CircleZone>(
     ObjectType.Circle,
-    ObjectType.Proximity,
     ObjectType.Knockback,
     ObjectType.RotateCW,
     ObjectType.RotateCCW,
 );
+
+export const ProximityStyle = {
+    Player: 'player',
+    Ground: 'ground',
+} as const;
+export type ProximityStyle = Enum<typeof ProximityStyle>;
+
+export interface ProximityZone extends RadiusObject, ColoredObject, HollowObject, BaseObject {
+    readonly type: typeof ObjectType.Proximity;
+    // default: Player
+    readonly proximityStyle?: ProximityStyle;
+}
+export const isProximityZone = makeObjectTest<ProximityZone>(ObjectType.Proximity);
 
 export interface StackZone extends StackCountObject, RadiusObject, ColoredObject, HollowObject, BaseObject {
     readonly type: typeof ObjectType.Stack;
@@ -375,27 +386,30 @@ export interface TowerZone extends RadiusObject, ColoredObject, StackCountObject
 export const isTowerZone = makeObjectTest<TowerZone>(ObjectType.Tower);
 
 export type Zone =
-    | CircleZone
-    | DonutZone
-    | ConeZone
     | ArcZone
-    | LineZone
-    | RectangleZone
+    | CircleZone
+    | ConeZone
+    | DonutZone
     | ExaflareZone
+    | LineZone
+    | PolygonZone
+    | ProximityZone
+    | RectangleZone
     | StarburstZone
     | TowerZone;
 export function isZone(object: UnknownObject): object is Zone {
     return (
-        isCircleZone(object) ||
-        isDonutZone(object) ||
-        isConeZone(object) ||
         isArcZone(object) ||
-        isLineZone(object) ||
-        isRectangleZone(object) ||
+        isCircleZone(object) ||
+        isConeZone(object) ||
+        isDonutZone(object) ||
         isExaflareZone(object) ||
+        isLineZone(object) ||
+        isPolygonZone(object) ||
+        isProximityZone(object) ||
+        isRectangleZone(object) ||
         isStarburstZone(object) ||
-        isTowerZone(object) ||
-        isPolygonZone(object)
+        isTowerZone(object)
     );
 }
 

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -296,7 +296,7 @@ export const ProximityStyle = {
 } as const;
 export type ProximityStyle = Enum<typeof ProximityStyle>;
 
-export interface ProximityZone extends RadiusObject, ColoredObject, HollowObject, BaseObject {
+export interface ProximityZone extends RadiusObject, ColoredObject, HollowObject, BaseObject, RotateableObject {
     readonly type: typeof ObjectType.Proximity;
     // default: Player
     readonly proximityStyle?: ProximityStyle;


### PR DESCRIPTION
It's added as a toggle for the existing proximity AoE, since it's not unique enough to warrant a new object type.

Also let these objects be rotatable. Like the eye object I'd not expect much use outside of meme plans, but the default orientation of the player-targeted marker in strategy boards is 180deg from the one in xivplan.